### PR TITLE
Pkg fix

### DIFF
--- a/remnux/config/spidermonkey.sls
+++ b/remnux/config/spidermonkey.sls
@@ -1,9 +1,9 @@
 include:
-  - remnux.packages.libmozjs-24-bin
+  - remnux.packages.libmozjs-52-0
 
 symlink-spidermonkey:
   file.symlink:
     - name: /usr/bin/js
     - target: /usr/bin/js24
     - watch:
-      - pkg: remnux-packages-libmozjs-24-bin
+      - pkg: libmozjs-52-0

--- a/remnux/packages/graphviz-dev.sls
+++ b/remnux/packages/graphviz-dev.sls
@@ -1,2 +1,0 @@
-graphviz-dev:
-  pkg.installed

--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -23,7 +23,7 @@ include:
   - remnux.packages.gdb
   - remnux.packages.geany
   - remnux.packages.git
-  - remnux.packages.graphviz-dev
+  - remnux.packages.graphviz
   - remnux.packages.graphviz
   - remnux.packages.ibus
   - remnux.packages.imagemagick
@@ -160,7 +160,7 @@ remnux-packages:
       - sls: remnux.packages.gdb
       - sls: remnux.packages.geany
       - sls: remnux.packages.git
-      - sls: remnux.packages.graphviz-dev
+      - sls: remnux.packages.libgraphviz-dev
       - sls: remnux.packages.graphviz
       - sls: remnux.packages.ibus
       - sls: remnux.packages.imagemagick

--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -40,7 +40,7 @@ include:
   - remnux.packages.libfuzzy-dev
   - remnux.packages.libjpeg-dev
   - remnux.packages.libjpeg8-dev
-  - remnux.packages.libmozjs-24-bin
+  - remnux.packages.libmozjs-52-0
   - remnux.packages.libncurses
   # - remnux.packages.libolecf-utils
   - remnux.packages.libsqlite3-dev
@@ -177,7 +177,6 @@ remnux-packages:
       - sls: remnux.packages.libfuzzy-dev
       - sls: remnux.packages.libjpeg-dev
       - sls: remnux.packages.libjpeg8-dev
-      - sls: remnux.packages.libmozjs-24-bin
       - sls: remnux.packages.libncurses
       # - sls: remnux.packages.libolecf-utils
       - sls: remnux.packages.libsqlite3-dev

--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -93,7 +93,7 @@ include:
   - remnux.packages.python-qt4
   - remnux.packages.python-scipy
   - remnux.packages.python-setuptools
-  - remnux.packages.python-software-properties
+  - remnux.packages.software-properties-common
   - remnux.packages.python-virtualenv
   - remnux.packages.python-volatility
   - remnux.packages.python-yara
@@ -230,7 +230,7 @@ remnux-packages:
       - sls: remnux.packages.python-qt4
       - sls: remnux.packages.python-scipy
       - sls: remnux.packages.python-setuptools
-      - sls: remnux.packages.python-software-properties
+      - sls: remnux.packages.software-properties-common
       - sls: remnux.packages.python-virtualenv
       - sls: remnux.packages.python-volatility
       - sls: remnux.packages.python-yara

--- a/remnux/packages/libgraphviz-dev.sls
+++ b/remnux/packages/libgraphviz-dev.sls
@@ -1,0 +1,2 @@
+libgraphviz-dev:
+  pkg.installed

--- a/remnux/packages/libmozjs-24-bin.sls
+++ b/remnux/packages/libmozjs-24-bin.sls
@@ -1,3 +1,0 @@
-remnux-packages-libmozjs-24-bin:
-  pkg.installed:
-    - name: libmozjs-24-bin

--- a/remnux/packages/libmozjs-52-0.sls
+++ b/remnux/packages/libmozjs-52-0.sls
@@ -1,0 +1,2 @@
+libmozjs-52-0:
+  pkg.installed

--- a/remnux/packages/python-software-properties.sls
+++ b/remnux/packages/python-software-properties.sls
@@ -1,2 +1,0 @@
-python-software-properties:
-  pkg.installed

--- a/remnux/packages/software-properties-common.sls
+++ b/remnux/packages/software-properties-common.sls
@@ -1,0 +1,2 @@
+software-properties-common:
+  pkg.installed

--- a/remnux/repos/openjdk.sls
+++ b/remnux/repos/openjdk.sls
@@ -1,9 +1,9 @@
 include:
-  - remnux.packages.python-software-properties
+  - remnux.packages.software-properties-common
 
 openjdk-repo:
   pkgrepo.managed:
     - ppa: openjdk-r/ppa
     - refresh_db: true
     - require:
-      - sls: remnux.packages.python-software-properties
+      - sls: remnux.packages.software-properties-common


### PR DESCRIPTION
Fix for:

migration of python-software-properties to software-properties-common 

migration of graphviz-dev to libgraphviz-dev
see: https://packages.ubuntu.com/search?keywords=graphviz-dev
