### PR TITLE
Build Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WIP: Working on 16.04 support.
 
 1. Have a Ubuntu Desktop VM available
 2. [Install SaltStack](#install-saltstack)
-3. `git clone https://github.com:REMnux/states.git /srv/salt`
+3. `git clone https://github.com/REMnux/salt-states.git /srv/salt`
 4. `sudo salt-call state.sls remnux`
 5. Sit back and enjoy
 

--- a/remnux/init.sls
+++ b/remnux/init.sls
@@ -6,6 +6,7 @@ include:
   - remnux.scripts
   - remnux.config
   - remnux.tools
+  - remnux.snap
 
 remnux:
   test.nop:
@@ -17,3 +18,4 @@ remnux:
       - sls: remnux.scripts
       - sls: remnux.config
       - sls: remnux.tools
+      - sls: remnux.snap

--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -59,7 +59,6 @@ include:
   - remnux.packages.openssl
   - remnux.packages.p7zip-full
   - remnux.packages.pdfresurrect
-  - remnux.packages.pdftk
   - remnux.packages.pkg-config
   - remnux.packages.pyew
   - remnux.packages.python-balbuzard
@@ -148,6 +147,8 @@ remnux-packages:
       - sls: remnux.packages.bundler
       - sls: remnux.packages.clamav-daemon
       - sls: remnux.packages.curl
+      - sls: remnux.packages.snapd
+      - sls: remnux.packages.snap	  
       - sls: remnux.packages.default-jre
       - sls: remnux.packages.docker
       - sls: remnux.packages.dos2unix
@@ -194,7 +195,6 @@ remnux-packages:
       - sls: remnux.packages.openssl
       - sls: remnux.packages.p7zip-full
       - sls: remnux.packages.pdfresurrect
-      - sls: remnux.packages.pdftk
       - sls: remnux.packages.pkg-config
       - sls: remnux.packages.pyew
       - sls: remnux.packages.python-balbuzard

--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -47,7 +47,6 @@ include:
   - remnux.packages.libssl-dev
   - remnux.packages.libtool
   - remnux.packages.libxml2-dev
-  - remnux.packages.libxslt-dev
   - remnux.packages.libxslt1-dev
   - remnux.packages.linux-headers
   - remnux.packages.ltrace
@@ -183,7 +182,6 @@ remnux-packages:
       - sls: remnux.packages.libssl-dev
       - sls: remnux.packages.libtool
       - sls: remnux.packages.libxml2-dev
-      - sls: remnux.packages.libxslt-dev
       - sls: remnux.packages.libxslt1-dev
       - sls: remnux.packages.linux-headers
       - sls: remnux.packages.ltrace

--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -95,7 +95,7 @@ include:
   - remnux.packages.python-setuptools
   - remnux.packages.software-properties-common
   - remnux.packages.python-virtualenv
-  - remnux.packages.python-volatility
+  - remnux.packages.volatility
   - remnux.packages.python-yara
   - remnux.packages.python
   - remnux.packages.python3-pip
@@ -231,7 +231,7 @@ remnux-packages:
       - sls: remnux.packages.python-setuptools
       - sls: remnux.packages.software-properties-common
       - sls: remnux.packages.python-virtualenv
-      - sls: remnux.packages.python-volatility
+      - sls: remnux.packages.volatility
       - sls: remnux.packages.python-yara
       - sls: remnux.packages.python
       - sls: remnux.packages.python3-pip

--- a/remnux/packages/libxslt-dev.sls
+++ b/remnux/packages/libxslt-dev.sls
@@ -1,2 +1,0 @@
-libxslt-dev:
-  pkg.installed

--- a/remnux/packages/pdftk.sls
+++ b/remnux/packages/pdftk.sls
@@ -1,2 +1,0 @@
-pdftk:
-  pkg.installed

--- a/remnux/packages/snap.sls
+++ b/remnux/packages/snap.sls
@@ -1,0 +1,4 @@
+remnux-package-snap:
+  pkg.installed:
+    - name: snap
+

--- a/remnux/packages/snapd.sls
+++ b/remnux/packages/snapd.sls
@@ -1,0 +1,4 @@
+remnux-package-snapd:
+  pkg.installed:
+    - name: snapd
+

--- a/remnux/packages/volatility.sls
+++ b/remnux/packages/volatility.sls
@@ -4,7 +4,7 @@ include:
   - remnux.python-packages.pefile
   - remnux.python-packages.yara-python
 
-python-volatility:
+volatility:
   pkg.installed:
     - require:
       - pkgrepo: sift-repo

--- a/remnux/python-packages/ioc-parser.sls
+++ b/remnux/python-packages/ioc-parser.sls
@@ -1,8 +1,9 @@
 include:
-  - remnux.packages.python-pip
+  - remnux.packages.python3-pip
 
 remnux-pip-ioc-parser:
   pip.installed:
     - name: ioc_parser
+    - bin_env: '/usr/bin/pip3'
     - require:
-      - sls: remnux.packages.python-pip
+      - sls: remnux.packages.python3-pip

--- a/remnux/python-packages/rekall.sls
+++ b/remnux/python-packages/rekall.sls
@@ -11,7 +11,8 @@ rekall-virtualenv:
   virtualenv.managed:
     - name: /opt/rekall
     - pip_pkgs:
-      - pip==9.0.3
+      - pip
+      - future==0.16.0
       - setuptools
       - wheel
       - rekall

--- a/remnux/repos/docker.sls
+++ b/remnux/repos/docker.sls
@@ -8,7 +8,7 @@ docker:
     - dist: {{ grains['lsb_distrib_codename'] }}
     - file: /etc/apt/sources.list.d/docker.list
     - keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
-    - keyserver: p80.pool.sks-keyservers.net
+    - keyserver: hkp://p80.pool.sks-keyservers.net:80
     - refresh_db: true
     - require:
       - sls: remnux.packages.apt-transport-https

--- a/remnux/snap/init.sls
+++ b/remnux/snap/init.sls
@@ -1,0 +1,7 @@
+include:
+  - remnux.snap.pdftk
+
+remnux-snap:
+  test.nop:
+    - require:
+      - sls: remnux.snap.pdftk

--- a/remnux/snap/pdftk.sls
+++ b/remnux/snap/pdftk.sls
@@ -1,0 +1,5 @@
+remnux-snap-pdftk:
+  #snap.installed:
+  #  - name: pdftk
+  cmd.run:
+    - name: snap install pdftk


### PR DESCRIPTION
Fixed ioc-parser by moving to python3
Fixed rekall by setting future==0.16.0
      Note: There is still  an error with fastchunking but rekall seems to still  work
Fixed pdftk by moving to snap, also requires snap to be installed.
      Note: reboot required for pdftk to work
Fixed incorrect incorrect keyserver url
Removed libxslt-dev (now libxslt1-dev)
Fixed volatility (package renamed)

This should fix all the build errors with ubuntu 18.04.  rekall with error with fastchunking but still seems to work.
