### PR TITLE
Updated thug and stpyv8 for 18.04

### DIFF
--- a/remnux/python-packages/stpyv8.sls
+++ b/remnux/python-packages/stpyv8.sls
@@ -1,25 +1,50 @@
+# Name: STPyV8
+# Website: https://github.com/area1/stpyv8
+# Description: Python3 and JavaScript interop engine, fork of the original PyV8 project
+# Category: Examine browser malware: Websites
+# Author: Area1 Security
+# License: https://github.com/area1/stpyv8/blob/master/LICENSE.txt
+# Notes: Required for thug
+
 include:
   - remnux.packages.git
-  - remnux.packages.python3-pip
+  - remnux.packages.python3
+  - remnux.packages.python
+  - remnux.packages.sudo
   - remnux.packages.libboost-python-dev
   - remnux.packages.libboost-system-dev
   - remnux.packages.libboost-dev
   - remnux.packages.python3-setuptools
-  - remnux.packages.python-pip
+  - remnux.packages.python-setuptools
   - remnux.packages.build-essential
-  - remnux.packages.sudo
 
-remnux-pip-stpyv8:
-  pip.installed:
-    - name: git+https://github.com/area1/stpyv8
-    - bin_env: /usr/bin/pip3
+remnux-git-stpyv8:
+  git.cloned:
+    - name: https://github.com/area1/stpyv8
+    - target: /tmp/stpyv8
+
+remnux-python-v8:
+  cmd.run:    
+    - name: /usr/bin/python setup.py v8
+    - cwd: /tmp/stpyv8/
     - require:
-      - sls: remnux.packages.git
-      - sls: remnux.packages.python3-pip
-      - sls: remnux.packages.libboost-python-dev
-      - sls: remnux.packages.python3-setuptools
-      - sls: remnux.packages.python-pip
-      - sls: remnux.packages.libboost-system-dev
-      - sls: remnux.packages.libboost-dev
-      - sls: remnux.packages.build-essential
-      - sls: remnux.packages.sudo
+      - sls: remnux.packages.python
+
+remnux-python3-stpyv8:
+  cmd.run:
+   - name: /usr/bin/python3 setup.py stpyv8
+   - cwd: /tmp/stpyv8/
+   - require:
+     - sls: remnux.packages.python3
+     - sls: remnux.packages.sudo
+     - sls: remnux.packages.libboost-python-dev
+     - sls: remnux.packages.libboost-system-dev
+     - sls: remnux.packages.libboost-dev
+
+remnux-python3-stpyv8-install:
+  cmd.run:
+   - name: /usr/bin/python3 setup.py install
+   - cwd: /tmp/stpyv8/
+   - require:
+     - sls: remnux.packages.python3
+

--- a/remnux/python-packages/thug.sls
+++ b/remnux/python-packages/thug.sls
@@ -1,51 +1,38 @@
-# Source: https://github.com/buffer/thug
+# Name: thug
+# Website: https://github.com/buffer/thug
+# Description: Python-based low-interaction honeyclient
+# Category: Examine browser malware: Websites
 # Author: Angelo Dell'Aera
+# License: https://github.com/buffer/thug/blob/master/LICENSE.txt
+# Notes: Based on Google's V8 engine, using STPyV8
 
 include:
-  - remnux.python-packages.pip
-  - remnux.packages.build-essential
-  - remnux.packages.python-dev
-  - remnux.packages.python-setuptools
-  - remnux.packages.libboost-python-dev
-  - remnux.packages.libboost-all-dev
-  - remnux.packages.python-pip
-  - remnux.packages.libxml2-dev
-  - remnux.packages.libxslt-dev
-  - remnux.packages.libtool
-  - remnux.packages.graphviz-dev
-  - remnux.packages.automake
-  - remnux.packages.libffi-dev
-  - remnux.packages.graphviz
-  - remnux.packages.libfuzzy-dev
-  - remnux.packages.libjpeg-dev
-  - remnux.packages.pkg-config
-  - remnux.packages.autoconf
+  - remnux.packages.git
+  - remnux.packages.python3
+  - remnux.packages.python3-setuptools
   - remnux.packages.libemu-dev
+  - remnux.packages.libgraphviz-dev
   - remnux.python-packages.stpyv8
-  - remnux.python-packages.pygraphviz
 
-remnux-thug:
-  pip.installed:
-    - name: git+https://github.com/buffer/thug.git@master
+remnux-git-thug:
+  git.cloned:
+    - name: https://github.com/buffer/thug
+    - target: /tmp/thug
+
+remnux-python3-build-thug:
+  cmd.run:
+    - name: /usr/bin/python3 setup.py build
+    - cwd: /tmp/thug/
     - require:
-      - sls: remnux.python-packages.pip
-      - sls: remnux.packages.build-essential
-      - sls: remnux.packages.python-dev
-      - sls: remnux.packages.python-setuptools
-      - sls: remnux.packages.libboost-python-dev
-      - sls: remnux.packages.libboost-all-dev
-      - sls: remnux.packages.python-pip
-      - sls: remnux.packages.libxml2-dev
-      - sls: remnux.packages.libxslt-dev
-      - sls: remnux.packages.libtool
-      - sls: remnux.packages.graphviz-dev
-      - sls: remnux.packages.automake
-      - sls: remnux.packages.libffi-dev
-      - sls: remnux.packages.graphviz
-      - sls: remnux.packages.libfuzzy-dev
-      - sls: remnux.packages.libjpeg-dev
-      - sls: remnux.packages.pkg-config
-      - sls: remnux.packages.autoconf
+      - sls: remnux.packages.python3
+      - sls: remnux.packages.python3-setuptools
+      - sls: remnux.python-packages.stpyv8
+
+remnux-python3-install-thug:
+  cmd.run:
+    - name: /usr/bin/python3 setup.py install
+    - cwd: /tmp/thug/
+    - require:
       - sls: remnux.packages.libemu-dev
-      - sls: remnux.python-packages.pyv8
-      - sls: remnux.python-packages.pygraphviz
+      - sls: remnux.packages.libgraphviz-dev
+      - sls: remnux.python-packages.stpyv8


### PR DESCRIPTION
Because there are specific build/install instructions for v8, stpyv8 and thug, these are split out to be cloned and installed using the supplied setup.py