### PR TITLE
NetworkMiner and Mono

### DIFF
--- a/remnux/packages/mono.sls
+++ b/remnux/packages/mono.sls
@@ -1,0 +1,14 @@
+remnux-mono-repo:
+  pkgrepo.managed:
+    - name: deb https://download.mono-project.com/repo/ubuntu stable-bionic main
+    - dist: stable-bionic
+    - file: /etc/apt/sources.list.d/mono-official-stable.list
+    - keyid: D3D831EF
+    - keyserver: keyserver.ubuntu.com
+    - refresh: true
+
+remnux-mono-install:
+  pkg.installed:
+    - fromrepo: stable-bionic
+    - pkgs:
+      - mono-devel

--- a/remnux/packages/mono.sls
+++ b/remnux/packages/mono.sls
@@ -1,3 +1,11 @@
+# Name: mono-devel
+# Website: https://www.mono-project.com
+# Description: mono cross-platform application development environment
+# Category: Examine browser malware: Websites
+# Author: Mono Project
+# License: https://github.com/mono/mono/blob/master/LICENSE
+# Notes:
+
 remnux-mono-repo:
   pkgrepo.managed:
     - name: deb https://download.mono-project.com/repo/ubuntu stable-bionic main

--- a/remnux/packages/networkminer.sls
+++ b/remnux/packages/networkminer.sls
@@ -1,3 +1,11 @@
+# Name: Network Miner Free Edition
+# Website: https://www.netresec.com/?download=NetworkMiner
+# Description: Network Forensic Analysis Tool, packet sniffer
+# Category: Examine browser malware: Websites
+# Author: NETRESEC AB
+# License: https://www.netresec.com/?page=NetworkMinerSourceCode
+# Notes: 
+
 remnux-wget-networkminer:
  cmd.run:
     - name: wget https://www.netresec.com/?download=NetworkMiner -O /tmp/nm.zip

--- a/remnux/packages/networkminer.sls
+++ b/remnux/packages/networkminer.sls
@@ -1,0 +1,27 @@
+remnux-wget-networkminer:
+ cmd.run:
+    - name: wget https://www.netresec.com/?download=NetworkMiner -O /tmp/nm.zip
+  
+remnux-networkminer-unzip:
+  archive.extracted:
+    - source: /tmp/nm.zip
+    - name: /opt/
+
+remnux-networkminer-del:
+  file.absent:
+    - name: /tmp/nm.zip
+
+remnux-networkminer-dirs:
+  file.directory:
+    - mode: 777
+    - names:
+      - /opt/NetworkMiner_2-5/AssembledFiles:
+        - source: /opt/NetworkMiner_2-5/AssembledFiles
+      - /opt/NetworkMiner_2-5/Captures:
+        - source: /opt/NetworkMiner_2-5/Captures
+    - recurse:
+      - mode
+
+/opt/NetworkMiner_2-5/NetworkMiner.exe:
+  file.managed:
+    - mode: 755


### PR DESCRIPTION
Added NetworkMiner state and mono as requirement. Mono is not a requirement for the state, only for the operation of NetworkMiner in a delivered state.