### PR TITLE
Changes to stpyv8 and thug, added reqs

### DIFF
--- a/remnux/packages/libemu.sls
+++ b/remnux/packages/libemu.sls
@@ -1,0 +1,41 @@
+# Name: libemu
+# Website: https://github.com/buffer/libemu
+# Description: x86 emulation and shellcode detection
+# Category: Examine browser malware: Websites
+# Author: Angelo Dell'Aera
+# License:
+# Notes: Requitement for thug
+
+include:
+  - remnux.packages.git
+  - remnux.packages.autoconf
+  - remnux.packages.libtool
+  - remnux.packages.build-essential
+
+remnux-git-libemu:
+  git.cloned:
+    - name: https://github.com/buffer/libemu.git
+    - target: /tmp/libemu
+
+remnux-autoreconf-libemu:
+  cmd.run:
+    - cwd: /tmp/libemu
+    - name: autoreconf -v -i
+    - require:
+      - sls: remnux.packages.autoconf
+      - sls: remnux.packages.libtool
+    - watch: 
+      - git: remnux-git-libemu
+
+remnux-config-make-libemu:
+  cmd.run:
+    - cwd: /tmp/libemu
+    - name: ./configure && make install
+    - watch:
+      - cmd: remnux-autoreconf-libemu
+
+remnux-ldconfig-libemu:
+  cmd.run:
+    - name: ldconfig
+    - watch:
+      - cmd: remnux-config-make-libemu

--- a/remnux/packages/libfuzzy2.sls
+++ b/remnux/packages/libfuzzy2.sls
@@ -1,0 +1,2 @@
+libfuzzy2:
+  pkg.installed

--- a/remnux/packages/tesseract-ocr.sls
+++ b/remnux/packages/tesseract-ocr.sls
@@ -1,0 +1,2 @@
+tesseract-ocr:
+  pkg.installed

--- a/remnux/python-packages/pytesseract.sls
+++ b/remnux/python-packages/pytesseract.sls
@@ -1,0 +1,17 @@
+# Name: pytesseract
+# Website: https://github.com/madmaze/pytesseract
+# Description: Python wrapper for Google Tesseract (OCR)
+# Category: Examine browser malware: Websites
+# Author: Matthias A Lee
+# License: https://github.com/madmaze/pytesseract/blob/master/LICENSE
+# Notes: Requirement/enhancement for thug
+
+include:
+  - remnux.packages.python3-pip
+  - remnux.packages.python3
+
+remnux-pytesseract:
+  cmd.run:
+    - name: /usr/bin/pip3 install --upgrade pytesseract
+    - require:
+      - sls: remnux.packages.python3-pip

--- a/remnux/python-packages/stpyv8.sls
+++ b/remnux/python-packages/stpyv8.sls
@@ -17,39 +17,23 @@ include:
   - remnux.packages.python3-setuptools
   - remnux.packages.python-setuptools
   - remnux.packages.build-essential
+  - remnux.packages.python3-pip
 
 remnux-git-stpyv8:
   git.cloned:
     - name: https://github.com/area1/stpyv8
     - target: /usr/local/src/stpyv8
 
-remnux-python-v8:
-  cmd.run:    
-    - name: /usr/bin/python setup.py v8
+remnux-pip3-stpyv8:
+  cmd.run:
     - cwd: /usr/local/src/stpyv8/
+    - name: /usr/bin/pip3 install wheels/ubuntu-18.04/stpyv8-7.9.317.33-cp36-cp36m-linux_x86_64.whl
     - require:
-      - sls: remnux.packages.python
+      - sls: remnux.packages.python3
+      - sls: remnux.packages.python3-pip
+      - sls: remnux.packages.sudo
+      - sls: remnux.packages.libboost-python-dev
+      - sls: remnux.packages.libboost-system-dev
+      - sls: remnux.packages.libboost-dev
     - watch:
       - git: remnux-git-stpyv8
-
-remnux-python-build-stpyv8:
-  cmd.run:
-   - name: /usr/bin/python3 setup.py stpyv8
-   - cwd: /usr/local/src/stpyv8/
-   - require:
-     - sls: remnux.packages.python3
-     - sls: remnux.packages.sudo
-     - sls: remnux.packages.libboost-python-dev
-     - sls: remnux.packages.libboost-system-dev
-     - sls: remnux.packages.libboost-dev
-   - watch:
-      - cmd: remnux-python-v8
-
-remnux-python-stpyv8:
-  cmd.run:
-   - name: /usr/bin/python3 setup.py install
-   - cwd: /usr/local/src/stpyv8/
-   - require:
-     - sls: remnux.packages.python3
-   - watch:
-      - cmd: remnux-python-build-stpyv8


### PR DESCRIPTION
Streamlined thug and stpyv8 installations. Added requirements (pytesseract, tesseract-ocr, libemu from buffer repo, and libfuzzy2).
Build time drastically reduced.