### PR TITLE
Attempted bug fixes for config states

### DIFF
--- a/.ci/rem-state.sh
+++ b/.ci/rem-state.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -x
+
+STATE=$1
+
+docker run -it --rm --name="remnux-state-${STATE}" -v `pwd`/remnux:/srv/salt/remnux --cap-add SYS_ADMIN remnux-saltstate:latest \
+  /bin/bash

--- a/remnux/config/bash-aliases.sls
+++ b/remnux/config/bash-aliases.sls
@@ -1,10 +1,9 @@
-{%- set user = salt['pillar.get']('remnux_user', 'remnux') -%}           
-
-{%- if user == "root" -%}
-  {%- set home = "/root" -%}
-{%- else -%}
-  {%- set home = salt['user.info'](user).home -%}
-{%- endif -%}
+{% set user = salt['pillar.get']('remnux_user', 'remnux') %}
+{% if user == "root" %}
+  {% set home = "/root" %}
+{% else %}
+  {% set home = "/home/" + user  %}
+{% endif %}
 
 include:
   - remnux.config.user

--- a/remnux/config/bash-rc.sls
+++ b/remnux/config/bash-rc.sls
@@ -1,10 +1,10 @@
-{%- set user = salt['pillar.get']('remnux_user', 'remnux') -%}           
+{% set user = salt['pillar.get']('remnux_user', 'remnux') %}
 
-{%- if user == "root" -%}
-  {%- set home = "/root" -%}
-{%- else -%}
-  {%- set home = salt['user.info'](user).home -%}
-{%- endif -%}
+{% if user == "root" %}
+  {% set home = "/root" %}
+{% else %}
+  {% set home = "/home/" + user  %}
+{% endif %}
 
 include:
   - remnux.config.user
@@ -15,7 +15,6 @@ remnux-config-bash-rc:
     - user: {{ user }}
     - group: {{ user }}
     - require:
-      - sls: remnux.config.user
       - user: remnux-user-{{ user }}
 
 remnux-config-bash-rc-noclobber:
@@ -23,7 +22,6 @@ remnux-config-bash-rc-noclobber:
     - name: {{ home }}/.bashrc
     - text: 'set -o noclobber'
     - require:
-      - sls: remnux.config.user
       - user: remnux-user-{{ user }}
     - watch:
       - file: remnux-config-bash-rc

--- a/remnux/config/thug.sls
+++ b/remnux/config/thug.sls
@@ -1,14 +1,14 @@
-{%- set user = salt['pillar.get']('remnux_user', 'remnux') -%}
-
-{%- if user == "root" -%}
-  {%- set home = "/root" -%}
-{%- else -%}
-  {%- set home = salt['user.info'](user).home -%}
-{%- endif -%}
+{% set user = salt['pillar.get']('remnux_user', 'remnux') %}
+{% if user == "root" %}
+  {% set home = "/root" %}
+{% else %}
+  {% set home = "/home/" + user %}
+{% endif %}
 
 include:
   - remnux.config.user
   - remnux.config.bash-rc
+  - remnux.config.bash-aliases
   - remnux.python-packages.thug
 
 remnux-config-thug:
@@ -21,6 +21,7 @@ remnux-config-thug:
     - makedirs: True
     - require:
       - user: remnux-user-{{ user }}
+      - sls: remnux.config.user
     - require:
       - sls: remnux.python-packages.thug
 
@@ -29,9 +30,9 @@ remnux-config-thug-bash-rc:
     - name: {{ home }}/.bashrc
     - text: 'THUG_LOGBASE=/var/log/thug'
     - require:
-      - sls: remnux.config.user
-      - sls: remnux.config.bash-rc
       - user: remnux-user-{{ user }}
+      - sls: remnux.config.user
     - watch:
-      - file: remnux-config-bash-rc
-      - file: remnux-config-thug
+       - file: remnux-config-bash-rc
+       - file: remnux-config-thug
+       - file: remnux-config-bash-aliases

--- a/remnux/config/user.sls
+++ b/remnux/config/user.sls
@@ -1,15 +1,17 @@
-{%- set user = salt['pillar.get']('remnux_user', 'remnux') -%}
-{%- set all_users = salt['user.list_users']() -%}
-
-{%- if user in all_users -%}
+{% set user = salt['pillar.get']('remnux_user', 'remnux') %}
+{% if user == "root" %}
+  {% set home = "/root" %}
+{% else %}
+  {% set home = "/home/" + user %}
+{% endif %}
+{% set all_users = salt['user.list_users']() %}
+{% if user in all_users %}
 
 remnux-user-{{ user }}:
   user.present:
     - name: {{ user }}
-    - home: /home/{{ user }}
-
-{%- else %}
-
+    - home: {{ home }}
+{% else %}
 remnux-user-{{ user }}:
   group.present:
     - name: {{ user }}
@@ -18,7 +20,7 @@ remnux-user-{{ user }}:
     - gid: {{ user }}
     - fullname: REMnux User
     - shell: /bin/bash
-    - home: /home/{{ user }}
+    - home: {{ home }}
     - password: $6$7n5jpcUZ$oh6U9W9mWKbtgIcY8y4buQZR3XMBOU2xUi4xGH9kvcB9o4IIsFLZ/.ffhqqVI0gkVchcJf3RSLxQhpgwXgmBR/
 
-{%- endif %}
+{% endif %}


### PR DESCRIPTION
The ['user.info'](user).home was not working, however syntax ['user.info'](user).get('home') was successful, however it revealed that 'home' was actually None in this scenario.
Made some modifications to make this work resulting in desired changes.

Ignore the rem-state.sh file (can't figure out how to delete it from this PR). I used it to build the docker with the latest Salt for 18.04 to see if it was a versioning issue. It is not.

Also, bash-aliases when pulled was empty. Didn't add a file.append in the event there was more you wanted to add.