### PR TITLE
Add shellcode2exe.py and inlineegg

### DIFF
--- a/remnux/python-packages/inlineegg.sls
+++ b/remnux/python-packages/inlineegg.sls
@@ -1,0 +1,15 @@
+# Name: InlineEgg-ng
+# Website: https://www.coresecurity.com/corelabs-research/open-source-tools/inlineegg
+# Description: Python module to write assembly programs
+# Category: Examine document files: Shellcode
+# Author: Gerardo Richarte (maintained by evandrix)
+# License: Custom license (free for noncommercial use)
+# Notes: 
+
+include:
+  - remnux.packages.python-pip
+
+InlineEgg-ng:
+  pip.installed:
+  - require:
+    - sls: remnux.packages.python-pip

--- a/remnux/scripts/shellcode2exe.sls
+++ b/remnux/scripts/shellcode2exe.sls
@@ -1,0 +1,21 @@
+# Name: shellcode2exe.py
+# Website: https://github.com/MarioVilas/shellcode_tools
+# Description: Shellcode to executable converter
+# Category: Examine document files: Shellcode
+# Author: Mario Vilas
+# License: https://github.com/MarioVilas/shellcode_tools/blob/master/shellcode2exe.py#L23
+# Notes: 
+
+include:
+  - remnux.python-packages.inlineegg
+
+remnux-scripts-shellcode2exe-source:
+  file.managed:
+    - name: /usr/local/bin/shellcode2exe.py
+    - source: https://raw.githubusercontent.com/MarioVilas/shellcode_tools/master/shellcode2exe.py
+    - source_hash: sha256=2cf1d7f06123b61bb6c92e5062c02ee9932ced6b5df70817468eee7ba14978e8
+    - mode: 755
+    - require:
+      - sls: remnux.python-packages.inlineegg
+
+


### PR DESCRIPTION
New inlineegg-ng package works well with shellcode2exe.py. Used the following example at bottom of page to compare and test. No issues, as long as directions from help menu are followed with appropriate quotes.

https://www.aldeid.com/wiki/Shellcode2exe