### PR TITLE
More header updates, removed peepdf from init until fixed

### DIFF
--- a/remnux/packages/rhino.sls
+++ b/remnux/packages/rhino.sls
@@ -1,2 +1,10 @@
+# Name: Rhino Debugger
+# Website: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Rhino/Debugger
+# Description: GUI JavaScript Debugger for scripts run in Rhino
+# Category: Examine browser malware: JavaScript
+# Author: Mozilla Project
+# License: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Rhino/License
+# Notes:
+
 rhino:
   pkg.installed

--- a/remnux/python-packages/init.sls
+++ b/remnux/python-packages/init.sls
@@ -33,7 +33,7 @@ include:
   - remnux.python-packages.wheel
   - remnux.python-packages.xortool
   - remnux.python-packages.xxxswf
-  - remnux.python-packages.peepdf
+# - remnux.python-packages.peepdf
   - remnux.python-packages.pype32
   - remnux.python-packages.thug
   - remnux.python-packages.unxor
@@ -75,7 +75,7 @@ remnux-python-packages:
       - sls: remnux.python-packages.wheel
       - sls: remnux.python-packages.xortool
       - sls: remnux.python-packages.xxxswf
-      - sls: remnux.python-packages.peepdf
+ #    - sls: remnux.python-packages.peepdf
       - sls: remnux.python-packages.pype32
       - sls: remnux.python-packages.thug
       - sls: remnux.python-packages.unxor

--- a/remnux/python-packages/jsbeautifier.sls
+++ b/remnux/python-packages/jsbeautifier.sls
@@ -1,3 +1,11 @@
+# Name: JS-Beautifier
+# Website: https://beautifier.io/
+# Description: Tool to reformat JavaScript scripts
+# Category: Examine browser malware: JavaScript
+# Author: Einar Lielmanis, Liam Newman, and contributors
+# License: https://github.com/beautify-web/js-beautify/blob/master/LICENSE
+# Notes: 
+
 include:
   - remnux.packages.python-pip
 

--- a/remnux/python-packages/peepdf.sls
+++ b/remnux/python-packages/peepdf.sls
@@ -1,28 +1,31 @@
-# Source: http://peepdf.eternal-todo.com/
+# Name: peepdf
+# Website: https://eternal-todo.com/tools/peepdf-pdf-analysis-tool
+# Description: Tool to breakout components of a given PDF file
+# Category: Examine document files: PDF
 # Author: Jose Miguel Esparza
-
-# For JavaScript deobfuscation peepef requires pyv8. However, pyv8
-# isn't building properly, so I commented it out.
+# License: https://github.com/jesparza/peepdf/blob/master/COPYING
+# Notes: 
 
 include:
   - remnux.packages.python-pip
   - remnux.packages.python-lxml
+  - remnux.packages.libemu
   - remnux.packages.libjpeg8-dev
   - remnux.packages.zlib1g-dev
-#  - remnux.python-packages.pyv8
   - remnux.python-packages.pylibemu
   - remnux.packages.libboost-python-dev
   - remnux.packages.libboost-thread-dev
 
-remnux-thug:
+remnux-peepdf:
   pip.installed:
     - name: peepdf
+    - pip_bin: /usr/bin/python2
     - require:
       - sls: remnux.packages.python-pip
       - sls: remnux.packages.python-lxml
+      - sls: remnux.packages.libemu
       - sls: remnux.packages.libjpeg8-dev
       - sls: remnux.packages.zlib1g-dev
-#      - sls: remnux.python-packages.pyv8
       - sls: remnux.python-packages.pylibemu
       - sls: remnux.packages.libboost-python-dev
       - sls: remnux.packages.libboost-thread-dev

--- a/remnux/python-packages/stpyv8.sls
+++ b/remnux/python-packages/stpyv8.sls
@@ -4,7 +4,7 @@
 # Category: Examine browser malware: Websites
 # Author: Area1 Security
 # License: https://github.com/area1/stpyv8/blob/master/LICENSE.txt
-# Notes: Required for thug
+# Notes: 
 
 include:
   - remnux.packages.git

--- a/remnux/scripts/extractscripts.sls
+++ b/remnux/scripts/extractscripts.sls
@@ -1,5 +1,10 @@
+# Name: ExtractScripts
+# Website: https://blog.didierstevens.com/programs/extractscripts/
+# Description: Extract scripts from HTML files
+# Category: Examine browser malware: JavaScript
 # Author: Didier Stevens
-# Source: https://blog.didierstevens.com/programs/extractscripts/
+# License: Free, unknown license
+# Notes: extractscripts.py
 
 remnux-scripts-extractscripts-source:
   file.managed:

--- a/remnux/scripts/pdf-parser.sls
+++ b/remnux/scripts/pdf-parser.sls
@@ -1,4 +1,10 @@
-# Author: Didier Stevens
+# Name: pdf-parser
+# Website: https://blog.didierstevens.com/programs/pdf-tools/
+# Description: Tool to identify fundamental elements used in a given PDF file
+# Category: Examine document files: PDF
+# Author: Didier Stevens 
+# License: Free, unknown license
+# Notes:
 
 include:
   - remnux.packages.python-yara

--- a/remnux/scripts/pdfid.sls
+++ b/remnux/scripts/pdfid.sls
@@ -1,4 +1,10 @@
+# Name: pdfid
+# Website: https://blog.didierstevens.com/programs/pdf-tools/
+# Description: Tool to identify pdf components in a given file
+# Category: Examine document files: PDF
 # Author: Didier Stevens
+# License: Free, unknown license
+# Notes: 
 
 remnux-scripts-pdfid-source:
   file.managed:

--- a/remnux/scripts/pdfobjflow.sls
+++ b/remnux/scripts/pdfobjflow.sls
@@ -1,4 +1,11 @@
-# Source: https://bitbucket.org/sebastiendamaye/pdfobjflow
+# Name: pdfobjflow
+# Website: https://bitbucket.org/sebastiendamaye/pdfobjflow
+# Description: Creates map of object flows from PDF's
+# Category: Examine document files: PDF
+# Author: Sebastien Damaye
+# License: Free, unknown license
+# Notes: 
+
 {%- set commit = "543c830b416244cfea3d70be5aface73bba66cc0" %}
 {%- set hash   = "059374f82a20107fa75f1f25f96cb3d24e9e53e98294c860496a810bae8e7b7d" %}
 include:


### PR DESCRIPTION
Header updates. Removed peepdf from init.sls, but left state there for future repairs. The currently working version of peepdf from jesparza is python2, but the version that gets installed from the pip repo is python3 which is semi-compatible with python2 using the six import. 

However, the version of peepdf from pip (https://github.com/jbremer/peepdf) does not decode the JS streams properly, and thus has even more reduced functionality than just operating without PyV8.

Until we can resolve this issue, peepdf is recommended for removal from the build.