### PR TITLE
CyberChef download URL update

### DIFF
--- a/remnux/tools/cyberchef.sls
+++ b/remnux/tools/cyberchef.sls
@@ -7,7 +7,7 @@
 # Notes: cyberchef
 
 {% set version = "9.20.3" -%}
-{% set hash = "5490446ace6880949938dbf708f8e370cf54f89f519912d18860e794e2c76c3d" -%}
+{% set hash = "033c0a44e0b80b6ac58bb5c00073eaccc0ae3e56853b91095930f48eeebcdaef" -%}
 
 include:
   - remnux.packages.firefox
@@ -16,7 +16,7 @@ remnux-tools-cyberchef:
   archive.extracted:
     - name: /usr/local/cyberchef
     - enforce_toplevel: False
-    - source: https://gchq.github.io/CyberChef/CyberChef_v{{ version }}.zip
+    - source: https://github.com/gchq/CyberChef/releases/download/v{{ version}}/CyberChef_v{{ version }}.zip
     - source_hash: sha256={{ hash }}
     - overwrite: True
     - require:


### PR DESCRIPTION
The download URL located in the top left corner at "https://gchq.github.io/CyberChef/", which was previously used to download the release, is not retained with each new version. Thus the state will not remain active once a new version is released, causing it to fail.

Since the 'releases' page at the github repo retains historical versions, it would be better to use this URL. Modified the hash and source of the state to reflect this change.