### PR TITLE
Peepdf updates

### DIFF
--- a/remnux/python-packages/init.sls
+++ b/remnux/python-packages/init.sls
@@ -33,7 +33,7 @@ include:
   - remnux.python-packages.wheel
   - remnux.python-packages.xortool
   - remnux.python-packages.xxxswf
-# - remnux.python-packages.peepdf
+  - remnux.python-packages.peepdf
   - remnux.python-packages.pype32
   - remnux.python-packages.thug
   - remnux.python-packages.unxor
@@ -75,7 +75,7 @@ remnux-python-packages:
       - sls: remnux.python-packages.wheel
       - sls: remnux.python-packages.xortool
       - sls: remnux.python-packages.xxxswf
- #    - sls: remnux.python-packages.peepdf
+      - sls: remnux.python-packages.peepdf
       - sls: remnux.python-packages.pype32
       - sls: remnux.python-packages.thug
       - sls: remnux.python-packages.unxor

--- a/remnux/python-packages/peepdf.sls
+++ b/remnux/python-packages/peepdf.sls
@@ -8,24 +8,16 @@
 
 include:
   - remnux.packages.python-pip
-  - remnux.packages.python-lxml
   - remnux.packages.libemu
   - remnux.packages.libjpeg8-dev
   - remnux.packages.zlib1g-dev
-  - remnux.python-packages.pylibemu
-  - remnux.packages.libboost-python-dev
-  - remnux.packages.libboost-thread-dev
 
-remnux-peepdf:
+remnux-tools-peepdf-source:
   pip.installed:
-    - name: peepdf
+    - name: git+https://github.com/digitalsleuth/peepdf.git
     - pip_bin: /usr/bin/python2
     - require:
       - sls: remnux.packages.python-pip
-      - sls: remnux.packages.python-lxml
       - sls: remnux.packages.libemu
       - sls: remnux.packages.libjpeg8-dev
       - sls: remnux.packages.zlib1g-dev
-      - sls: remnux.python-packages.pylibemu
-      - sls: remnux.packages.libboost-python-dev
-      - sls: remnux.packages.libboost-thread-dev


### PR DESCRIPTION
Cloned the peepdf repo, created a pip setup file, corrected a few errors, and removed the previous PyV8 requirements which were in there. Since PyV8 is not an option at this time (maybe in the future), I removed the libboosts. I've also removed python-lxml and pylibemu as they are installed during the pip install process.