### PR TITLE
Headers for tcpdump, added python 3 version of fakemail

### DIFF
--- a/remnux/packages/tcpdump.sls
+++ b/remnux/packages/tcpdump.sls
@@ -1,2 +1,10 @@
+# Name: tcpdump
+# Website: https://www.tcpdump.org/
+# Description: Command-line packet analyzer
+# Category: Network interactions: Sniffing
+# Author: https://github.com/the-tcpdump-group/tcpdump/blob/master/CREDITS
+# License: https://www.tcpdump.org/license.html
+# Notes: 
+
 tcpdump:
   pkg.installed

--- a/remnux/python-packages/fakemail.sls
+++ b/remnux/python-packages/fakemail.sls
@@ -1,0 +1,20 @@
+# Name: fakemail
+# Website: https://hg.sr.ht/~olly/fakemail
+# Description: Fake SMTP server useful for testing emails
+# Category: Network Interactions: Services
+# Author: Oliver Cope
+# License: https://hg.sr.ht/~olly/fakemail/browse/LICENSE.txt?rev=default
+# Notes: 
+
+include:
+  - remnux.packages.python-pip
+  - remnux.packages.python3-pip
+
+remnux-pip-fakemail:
+  pip.installed:
+    - name: fakemail
+    - bin_env: /usr/bin/python3
+    - require:
+      - sls: remnux.packages.python-pip
+      - sls: remnux.packages.python3-pip
+

--- a/remnux/python-packages/init.sls
+++ b/remnux/python-packages/init.sls
@@ -45,6 +45,7 @@ include:
   - remnux.python-packages.volatility
   - remnux.python-packages.ioc-writer
   - remnux.python-packages.volatility3
+  - remnux.python-packages.fakemail
 
 remnux-python-packages:
   test.nop:
@@ -95,3 +96,4 @@ remnux-python-packages:
       - sls: remnux.python-packages.volatility
       - sls: remnux.python-packages.ioc-writer
       - sls: remnux.python-packages.volatility3
+      - sls: remnux.python-packages.fakemail


### PR DESCRIPTION
Original fakemail tool was out of date and not maintained. This one is python 3, recently updated, and works well. Added state to python-packages init as well.