### PR TITLE
Updated IPWHOIS to Python 3, fixed shebangs

### DIFF
--- a/remnux/python-packages/ipwhois.sls
+++ b/remnux/python-packages/ipwhois.sls
@@ -1,7 +1,47 @@
+# Name: ipwhois
+# Website: https://github.com/secynic/ipwhois
+# Description: IP WHOIS lookup tools
+# Category: Network Interactions: Miscellaneous Network
+# Author: Philip Hane
+# License: https://github.com/secynic/ipwhois/blob/master/LICENSE.txt
+# Notes: ipwhois_cli.py, ipwhois_utils_cli.py
+
 include:
   - remnux.packages.python-pip
+  - remnux.packages.python3-pip
 
 ipwhois:
   pip.installed:
+    - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python-pip
+      - sls: remnux.packages.python3-pip
+
+remnux-python-packages-ipwhois_cli-shebang:
+  file.replace:
+    - name: /usr/local/bin/ipwhois_cli.py
+    - pattern: '#!/usr/bin/env python3'
+    - repl: '#!/usr/bin/env python3'
+    - prepend_if_not_found: True
+    - count: 1
+    - require:
+      - pip: ipwhois
+
+remnux-python-packages-ipwhois_utils-shebang:
+  file.replace:
+    - name: /usr/local/bin/ipwhois_utils_cli.py
+    - pattern: '#!/usr/bin/env python3'
+    - repl: '#!/usr/bin/env python3'
+    - prepend_if_not_found: True
+    - count: 1
+    - require:
+      - pip: ipwhois
+    - watch:
+      - file: remnux-python-packages-ipwhois_cli-shebang
+
+/usr/local/bin/ipwhois_cli.py:
+  file.managed:
+    - mode: 755
+
+/usr/local/bin/ipwhois_utils_cli.py:
+  file.managed:
+    - mode: 755


### PR DESCRIPTION
Original ipwhois was python 2, is capable of python 3, so installed with python3-pip. The shebangs were missing from both of the tools, so they were added, and strangely they were not marked as executable either. This was fixed with mode change for both files.