### PR TITLE
Fixed box-export shebang, added curl requirement for box-export

### DIFF
--- a/remnux/node-packages/box-js.sls
+++ b/remnux/node-packages/box-js.sls
@@ -4,14 +4,27 @@
 # Category: Examine browser malware: JavaScript
 # Author: CapacitorSet
 # License: https://github.com/CapacitorSet/box-js/blob/master/LICENSE
-# Notes:
+# Notes: box-js, box-export
 
 include:
   - remnux.packages.nodejs
   - remnux.packages.npm
+  - remnux.packages.curl
 
 box-js:
   npm.installed:
     - require:
       - sls: remnux.packages.nodejs
       - sls: remnux.packages.npm
+      - sls: remnux.packages.curl
+
+remnux-node-packages-box-export-shebang:
+  file.replace:
+    - name: /usr/local/bin/box-export
+    - pattern: '#!/usr/bin/env node'
+    - repl: '#!/usr/bin/env node'
+    - prepend_if_not_found: True
+    - count: 1
+    - require:
+      - npm: box-js
+


### PR DESCRIPTION
box-export required the node shebang at the top, and also requires curl to run properly. Added the requirement to this state so it can function independently.