### PR TITLE
Fixed requirement for vivbin, upgraded vivisect to PyQt5

### DIFF
--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -85,7 +85,7 @@ include:
   - remnux.packages.python-pyelftools
   - remnux.packages.python-pyperclip
   - remnux.packages.python-pyqt5
-  - remnux.packages.python-qt4
+  - remnux.packages.python-pyqt5-qtwebkit
   - remnux.packages.python-scipy
   - remnux.packages.python-setuptools
   - remnux.packages.software-properties-common
@@ -233,7 +233,7 @@ remnux-packages:
       - sls: remnux.packages.python-pyelftools
       - sls: remnux.packages.python-pyperclip
       - sls: remnux.packages.python-pyqt5
-      - sls: remnux.packages.python-qt4
+      - sls: remnux.packages.python-pyqt5-qtwebkit
       - sls: remnux.packages.python-scipy
       - sls: remnux.packages.python-setuptools
       - sls: remnux.packages.software-properties-common

--- a/remnux/packages/python-pyqt5-qtwebkit.sls
+++ b/remnux/packages/python-pyqt5-qtwebkit.sls
@@ -1,0 +1,2 @@
+python-pyqt5.qtwebkit:
+  pkg.installed

--- a/remnux/packages/python-qt4.sls
+++ b/remnux/packages/python-qt4.sls
@@ -1,2 +1,0 @@
-python-qt4:
-  pkg.installed

--- a/remnux/python-packages/vivisect.sls
+++ b/remnux/python-packages/vivisect.sls
@@ -9,7 +9,8 @@
 include:
   - remnux.packages.git
   - remnux.packages.python-pip
-  - remnux.packages.python-qt4
+  - remnux.packages.python-pyqt5
+  - remnux.packages.python-pyqt5-qtwebkit
 
 remnux-pip-vivisect:
   pip.installed:
@@ -17,4 +18,5 @@ remnux-pip-vivisect:
     - require:
       - sls: remnux.packages.git
       - sls: remnux.packages.python-pip
-      - sls: remnux.packages.python-qt4
+      - sls: remnux.packages.python-pyqt5
+      - sls: remnux.packages.python-pyqt5-qtwebkit


### PR DESCRIPTION
Vivisect required the python-pyqt5.qtwebkit package. Since Vivisect supports Qt5, it made sense to move the entire environment to Qt5. Removed python-qt4 since vivisect was the only tool which required it and was now not needed.
Updated the init state to reflect changes.