### PR TITLE
Removed require python-pip state

### DIFF
--- a/remnux/python-packages/oletools.sls
+++ b/remnux/python-packages/oletools.sls
@@ -7,14 +7,13 @@
 # Notes: mraptor, msodde, olebrowse, oledir, oleid, olemap, olemeta, oleobj, oletimes, olevba, pyxswf, rtfobj
 
 include:
-  - remnux.packages.python-pip
   - remnux.packages.python3-pip
   - remnux.packages.python3-tk
+  - remnux.packages.python-pip
 
 oletools:
   pip.installed:
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python-pip
       - sls: remnux.packages.python3-pip
       - sls: remnux.packages.python3-tk


### PR DESCRIPTION
A python2/3 issue. Even though bin_env specifically set to /usr/bin/python3, the installation is completed for python2. When tested manually, installs fine. Using cli in a VM, installed as python2.

Removed the 'require: python-pip' statement in the oletools pip.installed block. This worked in testing, should work in VM/CLI.