### PR TITLE
Fixed mode for runxlrd2.py

### DIFF
--- a/remnux/python-packages/xlmmacrodeobfuscator.sls
+++ b/remnux/python-packages/xlmmacrodeobfuscator.sls
@@ -17,3 +17,9 @@ remnux-pip-xlmmacrodeobfuscator:
     - require:
       - sls: remnux.packages.python3-pip
       - sls: remnux.packages.python-pip
+
+/usr/local/bin/runxlrd2.py:
+  file.managed:
+    - mode: 755
+    - require:
+      - pip: remnux-pip-xlmmacrodeobfuscator


### PR DESCRIPTION
A requirement of XLMMacroDeobfuscator is xlrd2 which, when installed, does not make one of its python scripts executable (/usr/local/bin/runxlrd2.py). Appended the mode change for this to the xlmmacro state to ensure all requirements are met and functional.