### PR TITLE
Added androwarn

### DIFF
--- a/remnux/python-packages/androwarn.sls
+++ b/remnux/python-packages/androwarn.sls
@@ -1,0 +1,16 @@
+# Name: Androwarn
+# Website: https://github.com/maaaaz/androwarn
+# Description: Static code analyzer for malicious Android applications
+# Category: Investigate mobile malware
+# Author: Thomas Debize
+# License: https://github.com/maaaaz/androwarn/blob/master/COPYING
+# Notes: 
+
+include:
+  - remnux.packages.python-pip
+
+remnux-androwarn-install:
+  pip.installed:
+    - name: androwarn
+    - require:
+      - sls: remnux.packages.python-pip

--- a/remnux/python-packages/init.sls
+++ b/remnux/python-packages/init.sls
@@ -46,6 +46,7 @@ include:
   - remnux.python-packages.ioc-writer
   - remnux.python-packages.volatility3
   - remnux.python-packages.fakemail
+  - remnux.python-packages.androwarn
 
 remnux-python-packages:
   test.nop:
@@ -97,3 +98,4 @@ remnux-python-packages:
       - sls: remnux.python-packages.ioc-writer
       - sls: remnux.python-packages.volatility3
       - sls: remnux.python-packages.fakemail
+      - sls: remnux.python-packages.androwarn


### PR DESCRIPTION
Added androwarn. There is a python3 version available, but does not properly install. It stops the installation due to a UTF-8 encoding problem. Python 2 version is still working and up-to-date.