### PR TITLE
Added RATDecoders and yara-python for python3

### DIFF
--- a/remnux/python-packages/init.sls
+++ b/remnux/python-packages/init.sls
@@ -48,6 +48,8 @@ include:
   - remnux.python-packages.fakemail
   - remnux.python-packages.pyperclip
   - remnux.python-packages.balbuzard
+  - remnux.python-packages.yara-python3
+  - remnux.python-packages.ratdecoders
 
 remnux-python-packages:
   test.nop:
@@ -101,3 +103,5 @@ remnux-python-packages:
       - sls: remnux.python-packages.fakemail
       - sls: remnux.python-packages.pyperclip
       - sls: remnux.python-packages.balbuzard
+      - sls: remnux.python-packages.yara-python3
+      - sls: remnux.python-pacakges.ratdecoders

--- a/remnux/python-packages/ratdecoders.sls
+++ b/remnux/python-packages/ratdecoders.sls
@@ -1,0 +1,24 @@
+# Name: RATDecoders
+# Website: https://github.com/kevthehermit/RATDecoders
+# Description: Python3 Decoders for Remote Access Trojans
+# Category: Statically examine PE files: Investigate
+# Author: Kevin Breen
+# License: https://github.com/kevthehermit/RATDecoders/blob/master/LICENSE
+# Notes: malconf
+
+include:
+  - remnux.packages.python-pip
+  - remnux.packages.python3-pip
+  - remnux.packages.git
+  - remnux.python-packages.androguard
+  - remnux.python-packages.yara-python3
+
+remnux-ratdecoders-install:
+  pip.installed:
+    - name: git+https://github.com/kevthehermit/RATDecoders.git
+    - bin_env: /usr/bin/python3
+    - require:
+      - sls: remnux.packages.python3-pip
+      - sls: remnux.packages.git
+      - sls: remnux.python-packages.androguard
+      - sls: remnux.python-packages.yara-python3

--- a/remnux/python-packages/yara-python3.sls
+++ b/remnux/python-packages/yara-python3.sls
@@ -1,0 +1,9 @@
+include:
+  - remnux.packages.python-pip
+  - remnux.packages.python3-pip
+
+yara-python:
+  pip.installed:
+    - bin_env: /usr/bin/python3
+    - require:
+      - sls: remnux.packages.python3-pip


### PR DESCRIPTION
Python3 version of yara-python required. Specified python3 androguard state to support RATDecoders to ensure correct version of androguard downloaded and remains unchanged by RATDecoders.
Note: In Docker testing, this produces an ascii error from the long_description in setup.py for README.md. This is because python3 expects UTF-* but the Docker locale by default is POSIX.

This state was tested by prepending LC_ALL=C.UTF-8 to the salt-call command:
`LC_ALL=C.UTF-8 salt-call -l debug --local --retcode-passthrough --state-output=mixed state.sls remnux.python-packages.ratdecoders`