### PR TITLE
Added DC3 MWCP

### DIFF
--- a/remnux/python-packages/dc3-mwcp.sls
+++ b/remnux/python-packages/dc3-mwcp.sls
@@ -1,0 +1,18 @@
+# Name: DC3-MWCP
+# Website: https://github.com/Defense-Cyber-Crime-Center/DC3-MWCP
+# Description: Python3 framework for parsing configuration information from malware
+# Category: Statically examine PE files: Investigate
+# Author: Defense Cyber Crime Center - United States Government
+# License: https://github.com/Defense-Cyber-Crime-Center/DC3-MWCP/blob/master/LICENSE.txt
+# Notes: mwcp
+
+include:
+  - remnux.packages.python-pip
+  - remnux.packages.python3-pip
+
+remnux-dc3-mwcp-install:
+  pip.installed:
+    - name: mwcp
+    - bin_env: /usr/bin/python3
+    - require:
+      - sls: remnux.packages.python3-pip

--- a/remnux/python-packages/init.sls
+++ b/remnux/python-packages/init.sls
@@ -48,6 +48,7 @@ include:
   - remnux.python-packages.fakemail
   - remnux.python-packages.pyperclip
   - remnux.python-packages.balbuzard
+  - remnux.python-packages.dc3-mwcp
 
 remnux-python-packages:
   test.nop:
@@ -101,3 +102,4 @@ remnux-python-packages:
       - sls: remnux.python-packages.fakemail
       - sls: remnux.python-packages.pyperclip
       - sls: remnux.python-packages.balbuzard
+      - sls: remnux.python-packages.dc3-mwcp


### PR DESCRIPTION
Added package to init state also. Usage of this tool requires a UTF-8 environment, thus testing in the Docker environment, which has a default locale of POSIX, one must: `export LC_ALL=C.UTF-8` or `export LANG=C.UTF-8` or equivalent language/locale requirements which meet a UTF-8 environment.