### PR TITLE
Updated rekall

### DIFF
--- a/remnux/python-packages/rekall.sls
+++ b/remnux/python-packages/rekall.sls
@@ -1,43 +1,28 @@
 include:
-  - ..packages.build-essential
-  - ..packages.python-dev
-  - ..packages.python-pip
-  - ..packages.libncurses
-  - ..packages.python-virtualenv
-  - .setuptools
-  - .wheel
+  - remnux.packages.python-pip
+  - remnux.packages.python3-pip
+  - remnux.packages.libncurses
 
-rekall-virtualenv:
-  virtualenv.managed:
-    - name: /opt/rekall
-    - pip_pkgs:
-      - pip
-      - future==0.16.0
-      - pyaff4==0.26.post6 
-      - sortedcontainers==1.5.7
-      - pyparsing==2.1.5  
-      - setuptools
-      - wheel
-      - rekall
-    - require:
-      - pkg: python-virtualenv
-
-rekall:
+remnux-rekall-requirements:
   pip.installed:
-    - name: rekall
-    - bin_env: /opt/rekall
+    - names: 
+      - future==0.16.0
+      - pyaff4==0.26.post6
+      - pybindgen
+      - capstone
+    - bin_env: /usr/bin/python3
     - require:
-      - pkg: python-dev
-      - pkg: python-pip
-      - pkg: libncurses
-      - pkg: build-essential
-      - pip: setuptools
-      - pip: wheel
-      - virtualenv: rekall-virtualenv
+      - sls: remnux.packages.libncurses
+      - sls: remnux.packages.python3-pip
 
-rekall-symlink:
-  file.symlink:
-    - name: /usr/local/bin/rekall
-    - target: /opt/rekall/bin/rekall
+remnux-rekall-install:
+  pip.installed:
+    - names:
+      - rekall
+      - rekall-agent
+    - bin_env: /usr/bin/python3
     - require:
-      - pip: rekall
+      - sls: remnux.packages.python3-pip
+      - pip: remnux-rekall-requirements
+    - watch:
+      - pip: remnux-rekall-requirements

--- a/remnux/python-packages/rekall.sls
+++ b/remnux/python-packages/rekall.sls
@@ -1,3 +1,11 @@
+# Name: rekall
+# Website: https://github.com/google/rekall
+# Description: Memory analysis framework
+# Category: Examine memory snapshots
+# Author: https://github.com/google/rekall/blob/master/AUTHORS.md
+# License: https://github.com/google/rekall/blob/master/LICENSE.txt
+# Notes: rekall, rekal
+
 include:
   - remnux.packages.python-pip
   - remnux.packages.python3-pip


### PR DESCRIPTION
Removed the virtualenv from rekall (as discussed), and added rekall and rekall-agent using python3. Install requires libncurses5-dev (already in packages as libncurses), and four additional pip packages prior to install: 
`future==0.16.0 pyaff4==0.26.post6 pybindgen capstone`
Once installed, rekall and rekall-agent can be installed using pip3.
Tested using [these](https://www.cfreds.nist.gov/mem/Basic_Memory_Images.html) memory dumps from NIST and testing various plugins. All ran successfully.