### PR TITLE
Added TrID, tridupdate

### DIFF
--- a/remnux/tools/init.sls
+++ b/remnux/tools/init.sls
@@ -21,6 +21,7 @@ include:
   - remnux.tools.bytehist
   - remnux.tools.binnavi
   - remnux.tools.de4dot
+  - remnux.tools.trid
 
 remnux-tools:
   test.nop:
@@ -47,3 +48,4 @@ remnux-tools:
       - sls: remnux.tools.bytehist
       - sls: remnux.tools.binnavi
       - sls: remnux.tools.de4dot
+      - sls: remnux.tools.trid

--- a/remnux/tools/trid.sls
+++ b/remnux/tools/trid.sls
@@ -1,0 +1,98 @@
+# Name: TrID
+# Website: https://mark0.net/soft-trid-e.html
+# Description: File type identifier
+# Category: Examine file properties and contents: Scan
+# Author: Marco Pontello
+# License: Free, unknown license
+# Notes: trid, tridupdate
+
+remnux-tools-trid-source:
+  file.managed:
+    - name: /usr/local/src/remnux/files/trid_linux_64.zip
+    - source: https://mark0.net/download/trid_linux_64.zip
+    - source_hash: sha256=3fb9ccfed650123f7bb5fc5a93ccbfcbc6ff98876cc659c8958c03a582467aa9
+    - makedirs: True
+
+remnux-tools-tridupdate-source:
+  file.managed:
+    - name: /usr/local/src/remnux/files/tridupdate.zip
+    - source: https://mark0.net/download/tridupdate.zip
+    - source_hash: sha256=3596167b5fa2f4adb3b6ee013c3f111a5c9e3b52f948e70e27423d8e69a1bb12
+    - require:
+      - file: remnux-tools-trid-source
+    - watch:
+      - file: remnux-tools-trid-source
+
+remnux-tools-trid-archive:
+  archive.extracted:
+    - name: /usr/local/trid_linux_64
+    - source: /usr/local/src/remnux/files/trid_linux_64.zip
+    - enforce_toplevel: False
+    - require:
+      - file: remnux-tools-trid-source
+    - watch:
+      - file: remnux-tools-tridupdate-source
+
+remnux-tools-tridupdate-archive:
+  archive.extracted:
+    - name: /usr/local/trid_linux_64
+    - source: /usr/local/src/remnux/files/tridupdate.zip
+    - enforce_toplevel: False
+    - require:
+      - file: remnux-tools-tridupdate-source
+    - watch:
+      - archive: remnux-tools-trid-archive
+
+remnux-tools-tridfiles-mode:
+  file.managed:
+    - names:
+      - /usr/local/trid_linux_64/trid
+      - /usr/local/trid_linux_64/tridupdate.py
+    - mode: 755
+    - watch:
+      - archive: remnux-tools-tridupdate-archive
+
+remnux-tools-tridupdate-shebang:
+  file.replace:
+    - name: /usr/local/trid_linux_64/tridupdate.py
+    - pattern: '#!/usr/bin/env python'
+    - repl: '#!/usr/bin/env python3'
+    - prepend_if_not_found: False
+    - count: 1
+    - require:
+      - archive: remnux-tools-tridupdate-archive
+
+remnux-tools-tridupdate-formatting:
+  file.replace:
+    - name: /usr/local/trid_linux_64/tridupdate.py
+    - pattern: '\r'
+    - repl: ''
+    - require:
+      - archive: remnux-tools-tridupdate-archive
+
+remnux-tools-tridupdate-defs-location:
+  file.replace:
+    - name: /usr/local/trid_linux_64/tridupdate.py
+    - pattern: 'default="triddefs.trd"'
+    - repl: 'default="/usr/local/trid_linux_64/triddefs.trd"'
+    - count: 1
+    - require:
+      - archive: remnux-tools-tridupdate-archive
+
+/usr/local/bin/trid:
+  file.symlink:
+    - target: /usr/local/trid_linux_64/trid
+    - watch:
+      - file: remnux-tools-tridfiles-mode
+
+/usr/local/bin/tridupdate:
+  file.symlink:
+    - target: /usr/local/trid_linux_64/tridupdate.py
+    - watch:
+      - file: remnux-tools-tridfiles-mode
+
+remnux-tools-tridupdate-run:
+  cmd.wait:
+    - name: /usr/local/bin/tridupdate
+    - watch:
+      - file: /usr/local/bin/tridupdate


### PR DESCRIPTION
tridupdate required some minor changes to run properly. Was CRLF formatted (Dos formatted), so I removed the extraneous '\r'. Modified the default download location for the defs file to be the same location as the trid binary (/usr/local/trid_linux_64).

Symlinks created in /usr/local/bin. The program was not downloaded/extracted directly to /usr/local/bin in order to keep it uncluttered with the readme and defs file, which should remain with the binary.