### PR TITLE
Removed python-yara in favor of yara-python

### DIFF
--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -89,7 +89,6 @@ include:
   - remnux.packages.python-setuptools
   - remnux.packages.software-properties-common
   - remnux.packages.python-virtualenv
-  - remnux.packages.python-yara
   - remnux.packages.python
   - remnux.packages.python3-pip
   - remnux.packages.qpdf
@@ -242,7 +241,6 @@ remnux-packages:
       - sls: remnux.packages.python-setuptools
       - sls: remnux.packages.software-properties-common
       - sls: remnux.packages.python-virtualenv
-      - sls: remnux.packages.python-yara
       - sls: remnux.packages.python
       - sls: remnux.packages.python3-pip
       - sls: remnux.packages.qpdf

--- a/remnux/packages/python-yara.sls
+++ b/remnux/packages/python-yara.sls
@@ -1,2 +1,0 @@
-python-yara:
-  pkg.installed

--- a/remnux/python-packages/xxxswf.sls
+++ b/remnux/python-packages/xxxswf.sls
@@ -9,7 +9,7 @@
 include:
   - remnux.packages.git
   - remnux.packages.python-pip
-  - remnux.packages.python-yara
+  - remnux.python-packages.yara-python
   - remnux.python-packages.pylzma
 
 remnux-pip-xxxswf:
@@ -18,5 +18,5 @@ remnux-pip-xxxswf:
     - require:
       - sls: remnux.packages.git
       - sls: remnux.packages.python-pip
-      - sls: remnux.packages.python-yara
+      - sls: remnux.python-packages.yara-python
       - sls: remnux.python-packages.pylzma

--- a/remnux/scripts/nomorexor.sls
+++ b/remnux/scripts/nomorexor.sls
@@ -7,7 +7,7 @@
 # Notes:
 
 include:
-  - remnux.packages.python-yara
+  - remnux.python-packages.yara-python
 
 remnux-scripts-nomorexor-source:
   file.managed:
@@ -17,5 +17,5 @@ remnux-scripts-nomorexor-source:
   - mode: 755
   - makedirs: false
   - require:
-    - sls: remnux.packages.python-yara
+    - sls: remnux.python-packages.yara-python
 

--- a/remnux/scripts/pdf-parser.sls
+++ b/remnux/scripts/pdf-parser.sls
@@ -7,19 +7,19 @@
 # Notes:
 
 include:
-  - remnux.packages.python-yara
+  - remnux.python-packages.yara-python
 
 remnux-scripts-pdf-parser-source:
   file.managed:
-    - name: /usr/local/src/remnux/files/pdf-parser_V0_7_1.zip
-    - source: https://didierstevens.com/files/software/pdf-parser_V0_7_1.zip
-    - source_hash: sha256=D2C8E0599A84127C36656AA2600F9668A3CB12EF306D28752D6D8AC436A89D1A
+    - name: /usr/local/src/remnux/files/pdf-parser_V0_7_4.zip
+    - source: https://didierstevens.com/files/software/pdf-parser_V0_7_4.zip
+    - source_hash: sha256=FC318841952190D51EB70DAFB0666D7D19652C8839829CC0C3871BBF7E155B6A
     - makedirs: True
 
 remnux-scripts-pdf-parser-archive:
   archive.extracted:
-    - name: /usr/local/src/remnux/pdf-parser_V0_7_1
-    - source: /usr/local/src/remnux/files/pdf-parser_V0_7_1.zip
+    - name: /usr/local/src/remnux/pdf-parser_V0_7_4
+    - source: /usr/local/src/remnux/files/pdf-parser_V0_7_4.zip
     - enforce_toplevel: False
     - watch:
       - file: remnux-scripts-pdf-parser-source
@@ -27,9 +27,9 @@ remnux-scripts-pdf-parser-archive:
 remnux-scripts-pdf-parser-binary:
   file.managed:
     - name: /usr/local/bin/pdf-parser.py
-    - source: /usr/local/src/remnux/pdf-parser_V0_7_1/pdf-parser.py
+    - source: /usr/local/src/remnux/pdf-parser_V0_7_4/pdf-parser.py
     - mode: 755
     - require:
-      - sls: remnux.packages.python-yara
+      - sls: remnux.python-packages.yara-python
     - watch:
       - archive: remnux-scripts-pdf-parser-archive


### PR DESCRIPTION
xxxswf, nomorexor, and pdf-parser all require yara for signature scanning, but not python-yara specifically. 
Since the ubuntu pkg python-yara is version 3.8 and the current version of yara-python (from pip) is 4.0.2, and these three tools are compatible with the latest version, changed the requirement for yara to be yara-python.

No other tools require python-yara at this time, to removed the state as well, and removed the reference in the packages init state.

Additionally, upgraded pdf-parser from 0.7.1 to 0.7.4