### PR TITLE
Added ExifTool, created perl-packages

### DIFF
--- a/remnux/addon.sls
+++ b/remnux/addon.sls
@@ -11,6 +11,7 @@ include:
   - remnux.config
   - remnux.tools
   - remnux.node-packages
+  - remnux.perl-packages
 
 remnux-addon-version-file:
   file.managed:
@@ -27,3 +28,4 @@ remnux-addon-version-file:
       - sls: remnux.config
       - sls: remnux.tools
       - sls: remnux.node-packages
+      - sls: remnux.perl-packages

--- a/remnux/perl-packages/exiftool.sls
+++ b/remnux/perl-packages/exiftool.sls
@@ -1,0 +1,20 @@
+# Name: ExifTool
+# Website: https://exiftool.org/
+# Description: Tool to read from, write to, and edit EXIF metadata of various file types
+# Category: Examine file properties and contents: Scan
+# Author: Phil Harvey
+# License: https://exiftool.org/#license
+# Notes: 
+
+include:
+  - remnux.packages.perl
+  - remnux.packages.build-essential
+
+remnux-perl-packages-exiftool:
+  cmd.run:
+    - name: cpan install Image::ExifTool
+    - env:
+      - PERL_MM_USE_DEFAULT: 1
+    - require:
+      - sls: remnux.packages.perl
+      - sls: remnux.packages.build-essential

--- a/remnux/perl-packages/init.sls
+++ b/remnux/perl-packages/init.sls
@@ -1,0 +1,7 @@
+include:
+  - remnux.perl-packages.exiftool
+
+remnux-perl-packages:
+  test.nop:
+    - require:
+      - sls: remnux.perl-packages.exiftool


### PR DESCRIPTION
ExifTool from cpan is more up to date (one minor version behind current) than Ubuntu pkg (2 major versions behind). 
Since it requires installation using cpan, I added the PERL_MM_USE_DEFAULT: 1 environment option in the exiftool state to force cpan to accept defaults. This is the equivalent of providing '-y' to apt install.

This also creates a folder perl-packages, adds an init state, and adds the perl-packages folder to the addon state. Since dedicated calls the 'addon' pack anyways, there was no need to add it to dedicated.