### PR TITLE
Fixed trid locale issue

### DIFF
--- a/remnux/tools/trid.sls
+++ b/remnux/tools/trid.sls
@@ -79,11 +79,16 @@ remnux-tools-tridupdate-defs-location:
     - require:
       - archive: remnux-tools-tridupdate-archive
 
-/usr/local/bin/trid:
-  file.symlink:
-    - target: /usr/local/trid_linux_64/trid
+remnux-tools-trid-wrapper:
+  file.managed:
+    - name: /usr/local/bin/trid
+    - mode: 755
+    - replace: False
     - watch:
       - file: remnux-tools-tridfiles-mode
+    - contents:
+      - '#!/bin/bash'
+      - LC_CTYPE=C.UTF-8 /usr/local/trid_linux_64/trid ${*}
 
 /usr/local/bin/tridupdate:
   file.symlink:


### PR DESCRIPTION
Trid has a locale issue which, when locale is not set to C or C.UTF-8, causes an assertion error in loadlocale.c
The error itself is a known issue in Debian/Ubuntu with glibc (https://sourceware.org/bugzilla/show_bug.cgi?id=17318) (https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1772918), and can only be bypassed at this time.

Added a wrapper to the state file which specifies the LC_CTYPE context of C.UTF-8 to call trid and avoid setting this in the locale permanently.

To note, this particular wrapper does not work well in docker, based on the lack of locales, desktop environment, and user config. However, without the wrapper, trid works fine in docker due to the POSIX locale being set as default, and this works fine with trid apparently.