### PR TITLE
Added VirusTotal API

### DIFF
--- a/remnux/python-packages/virustotal-api.sls
+++ b/remnux/python-packages/virustotal-api.sls
@@ -1,3 +1,21 @@
+# Name: VirusTotal API
+# Website: https://github.com/doomedraven/VirusTotalApi
+# Description: Python 3 tool to query and interact with VirusTotal at a CLI
+# Category: Examine file properties and contents: Hashes
+# Author: doomedraven
+# License: https://github.com/doomedraven/VirusTotalApi/blob/master/LICENSE.md
+# Notes: vt
+
+include:
+  - remnux.packages.python-pip
+  - remnux.packages.python3-pip
+  - remnux.packages.git
+
 remnux-python-package-virustotal-api:
   pip.installed:
-    - name: virustotal-api
+    - name: git+https://github.com/doomedraven/VirusTotalApi
+    - bin_env: /usr/bin/python3
+    - require:
+      - sls: remnux.packages.python3-pip
+      - sls: remnux.packages.git
+


### PR DESCRIPTION
Previous virustotal-api from pip is still python2, and is not the source for the one indicated in the mindmap. This version is feature rich and seems to be more regularly updated.