### PR TITLE
Added virtualenv for viper-framework

### DIFF
--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -87,7 +87,6 @@ include:
   - remnux.packages.python-scipy
   - remnux.packages.python-setuptools
   - remnux.packages.software-properties-common
-  - remnux.packages.python-virtualenv
   - remnux.packages.python
   - remnux.packages.python3-pip
   - remnux.packages.qpdf
@@ -148,6 +147,10 @@ include:
   - remnux.packages.bearparser
   - remnux.packages.signsrch
   - remnux.packages.pycdc
+  - remnux.packages.libusb-1
+  - remnux.packages.python3-venv
+  - remnux.packages.python3-virtualenv
+  - remnux.packages.virtualenv
 
 remnux-packages:
   test.nop:
@@ -239,7 +242,6 @@ remnux-packages:
       - sls: remnux.packages.python-scipy
       - sls: remnux.packages.python-setuptools
       - sls: remnux.packages.software-properties-common
-      - sls: remnux.packages.python-virtualenv
       - sls: remnux.packages.python
       - sls: remnux.packages.python3-pip
       - sls: remnux.packages.qpdf
@@ -301,3 +303,8 @@ remnux-packages:
       - sls: remnux.packages.bearparser
       - sls: remnux.packages.signsrch
       - sls: remnux.packages.pycdc
+      - sls: remnux.packages.libusb-1
+      - sls: remnux.packages.python3-venv
+      - sls: remnux.packages.python3-virtualenv
+      - sls: remnux.packages.virtualenv
+

--- a/remnux/packages/libusb-1.sls
+++ b/remnux/packages/libusb-1.sls
@@ -1,0 +1,2 @@
+libusb-1.0-0:
+  pkg.installed

--- a/remnux/packages/python-virtualenv.sls
+++ b/remnux/packages/python-virtualenv.sls
@@ -1,2 +1,0 @@
-python-virtualenv:
-  pkg.installed

--- a/remnux/packages/python3-venv.sls
+++ b/remnux/packages/python3-venv.sls
@@ -1,0 +1,2 @@
+python3-venv:
+  pkg.installed

--- a/remnux/packages/python3-virtualenv.sls
+++ b/remnux/packages/python3-virtualenv.sls
@@ -1,0 +1,2 @@
+python3-virtualenv:
+  pkg.installed

--- a/remnux/packages/virtualenv.sls
+++ b/remnux/packages/virtualenv.sls
@@ -1,0 +1,2 @@
+virtualenv:
+  pkg.installed

--- a/remnux/python-packages/init.sls
+++ b/remnux/python-packages/init.sls
@@ -51,6 +51,7 @@ include:
   - remnux.python-packages.yara-python3
   - remnux.python-packages.ratdecoders
   - remnux.python-packages.poster
+  - remnux.python-packages.viper-framework
 
 remnux-python-packages:
   test.nop:
@@ -107,3 +108,4 @@ remnux-python-packages:
       - sls: remnux.python-packages.yara-python3
       - sls: remnux.python-packages.ratdecoders
       - sls: remnux.python-packages.poster
+      - sls: remnux.python-packages.viper-framework

--- a/remnux/python-packages/viper-framework.sls
+++ b/remnux/python-packages/viper-framework.sls
@@ -1,0 +1,100 @@
+# Name: viper-framework
+# Website: https://github.com/viper-framework/viper
+# Description: Binary analysis and management framework
+# Category: Process multiple samples
+# Author: Claudio Guarnieri
+# License: https://github.com/viper-framework/viper/blob/master/LICENSE
+# Notes: viper
+
+include:
+  - remnux.packages.libssl-dev
+  - remnux.packages.swig
+  - remnux.packages.libusb-1
+  - remnux.packages.libfuzzy-dev
+  - remnux.packages.git
+  - remnux.packages.virtualenv
+  - remnux.packages.python-pip
+  - remnux.packages.python3-pip
+  - remnux.packages.python3-virtualenv
+  - remnux.packages.python3-venv
+
+remnux-python-packages-viper-virtualenv:
+  virtualenv.managed:
+    - name: /opt/viper
+    - venv_bin: /usr/bin/virtualenv
+    - python: /usr/bin/python3
+    - pip_pkgs:
+      - pip
+      - setuptools
+      - wheel
+    - require:
+      - sls: remnux.packages.python3-pip
+      - sls: remnux.packages.python3-virtualenv
+      - sls: remnux.packages.python3-venv
+      - sls: remnux.packages.virtualenv
+
+remnux-python-packages-viper-install:
+  pip.installed:
+    - name: viper-framework
+    - bin_env: /opt/viper/bin/python3
+    - require:
+      - sls: remnux.packages.libssl-dev
+      - sls: remnux.packages.swig
+      - sls: remnux.packages.libusb-1
+      - sls: remnux.packages.libfuzzy-dev
+      - sls: remnux.packages.git
+      - sls: remnux.packages.python3-pip
+      - virtualenv: remnux-python-packages-viper-virtualenv
+
+remnux-python-packages-viper-requirements:
+  pip.installed:
+    - pkgs:
+      - androguard==3.3.5
+      - pyclamd==0.4.0
+      - pypdns==1.4.1
+      - pyelftools==0.25
+      - dnspython==1.16.0
+      - olefile==0.46
+      - git+https://github.com/viper-framework/xxxswf.git@9188316eb7a179326d99bfde9fe0184bb3cee6a3#egg=xxxswf
+      - pyparsing==2.4.7
+      - packaging==19.0
+      - pefile==2019.4.18
+      - bitstring==3.1.7
+      - pyasn1==0.4.8
+      - pyopenssl==19.1.0
+      - cryptography==2.9.2
+      - cffi==1.14.0
+      - asn1crypto==1.3.0
+      - idna==2.9
+      - ipaddress==1.0.23
+      - pycparser==2.20
+      - pypssl==2.1
+      - r2pipe==1.2.0
+      - beautifulsoup4==4.7.1
+      - pylzma==0.5.0
+      - virustotal-api==1.1.10
+      - yara-python==3.10.0
+      - pycrypto==2.6.1
+      - git+https://github.com/viper-framework/ScrapySplashWrapper.git#egg=ScrapySplashWrapper
+      - git+https://github.com/sebdraven/verify-sigs.git#egg=verify-sigs
+      - oletools==0.54.1
+      - git+https://github.com/MISP/PyTaxonomies.git#egg=PyTaxonomies
+      - git+https://github.com/MISP/PyMISPGalaxies.git#egg=PyMISPGalaxies
+      - ocrd-pyexiftool==0.2.0
+      - jbxapi>=3.1.3,<4
+      - pymisp[fileobjects,virustotal] >= 2.4.96
+      - jsonschema<4.0.0,>=3.2.0
+      - lief==0.10.1
+      - snoopdroid==2.1
+    - bin_env: /opt/viper/bin/python3
+    - require:
+      - pip: remnux-python-packages-viper-install
+    - watch:
+      - pip: remnux-python-packages-viper-install
+
+remnux-python-packages-viper-symlink:
+  file.symlink:
+    - name: /usr/local/bin/viper
+    - target: /opt/viper/bin/viper
+    - require:
+      - pip: remnux-python-packages-viper-install


### PR DESCRIPTION
Added viper-framework and placed in its own python3 virtualenv.
There is an issue in the requirements.txt file on the viper-modules repo, with prevents PyMISPGalaxies and verify-sigs to be downloaded. Additionally, the jsonschema version indicated by the requirements.txt there is out of date and won't be installed based on the python version. Increased the minimum requirement level of this.

Instead of having a requirements.txt file in the salt-states repo here, it's easier to have the one salt state with all the requirements in it, so only one file needs to be managed for the future. Users of viper-framework will still have issues running 'update-modules' because it will still try to run the pip3 install -U -r requirements.txt from the viper-modules repo (and get the aforementioned errors), but since these requirements are pre-installed, this error can be safely ignored.

Finally, since we removed rekall, the python-virtualenv was no longer required, so I removed its state, and its entries in the packages init state.