### PR TITLE
xxxswf update

### DIFF
--- a/remnux/python-packages/init.sls
+++ b/remnux/python-packages/init.sls
@@ -19,7 +19,6 @@ include:
   - remnux.python-packages.pydeep
   - remnux.python-packages.pyelftools
   - remnux.python-packages.pygeoip
-  - remnux.python-packages.pylzma
   - remnux.python-packages.pypdns
   - remnux.python-packages.pypssl
   - remnux.python-packages.r2pipe
@@ -51,6 +50,7 @@ include:
   - remnux.python-packages.yara-python3
   - remnux.python-packages.ratdecoders
   - remnux.python-packages.poster
+  - remnux.python-packages.pylzma-python3
 
 remnux-python-packages:
   test.nop:
@@ -75,7 +75,6 @@ remnux-python-packages:
       - sls: remnux.python-packages.pydeep
       - sls: remnux.python-packages.pyelftools
       - sls: remnux.python-packages.pygeoip
-      - sls: remnux.python-packages.pylzma
       - sls: remnux.python-packages.pypdns
       - sls: remnux.python-packages.pypssl
       - sls: remnux.python-packages.r2pipe
@@ -107,3 +106,4 @@ remnux-python-packages:
       - sls: remnux.python-packages.yara-python3
       - sls: remnux.python-packages.ratdecoders
       - sls: remnux.python-packages.poster
+      - sls: remnux.python-packages.pylzma-python3

--- a/remnux/python-packages/pylzma-python3.sls
+++ b/remnux/python-packages/pylzma-python3.sls
@@ -1,0 +1,10 @@
+include:
+  - remnux.packages.python-pip
+  - remnux.packages.python3-pip
+
+remnux-python-packages-pylzma-python3:
+  pip.installed:
+    - name: pylzma
+    - bin_env: /usr/bin/python3
+    - require:
+      - sls: remnux.packages.python3-pip

--- a/remnux/python-packages/pylzma.sls
+++ b/remnux/python-packages/pylzma.sls
@@ -1,7 +1,0 @@
-include:
-  - remnux.packages.python-pip
-
-pylzma:
-  pip.installed:
-    - require:
-      - sls: remnux.packages.python-pip

--- a/remnux/python-packages/xxxswf.sls
+++ b/remnux/python-packages/xxxswf.sls
@@ -1,22 +1,24 @@
 # Name: xxxswf
-# Website: https://bitbucket.org/Alexander_Hanel/xxxswf.git
+# Website: https://github.com/viper-framework/xxxswf
 # Description: Python script for analyzing Flash SWF files
 # Category: Examine browser malware: Flash
 # Author: Alexander Hanel
-# License: https://bitbucket.org/Alexander_Hanel/xxxswf/src/master/LICENSE.txt
+# License: https://github.com/viper-framework/xxxswf/blob/master/LICENSE.txt
 # Notes: 
 
 include:
   - remnux.packages.git
   - remnux.packages.python-pip
-  - remnux.python-packages.yara-python
-  - remnux.python-packages.pylzma
+  - remnux.packages.python3-pip
+  - remnux.python-packages.yara-python3
+  - remnux.python-packages.pylzma-python3
 
-remnux-pip-xxxswf:
+remnux-python-packages-xxxswf:
   pip.installed:
-    - name: git+https://bitbucket.org/Alexander_Hanel/xxxswf.git@c231234
+    - name: git+https://github.com/digitalsleuth/xxxswf.git
+    - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.packages.git
-      - sls: remnux.packages.python-pip
-      - sls: remnux.python-packages.yara-python
-      - sls: remnux.python-packages.pylzma
+      - sls: remnux.packages.python3-pip
+      - sls: remnux.python-packages.yara-python3
+      - sls: remnux.python-packages.pylzma-python3

--- a/remnux/python-packages/xxxswf.sls
+++ b/remnux/python-packages/xxxswf.sls
@@ -1,9 +1,9 @@
 # Name: xxxswf
-# Website: https://github.com/viper-framework/xxxswf
+# Website: https://github.com/digitalsleuth/xxxswf
 # Description: Python script for analyzing Flash SWF files
 # Category: Examine browser malware: Flash
 # Author: Alexander Hanel
-# License: https://github.com/viper-framework/xxxswf/blob/master/LICENSE.txt
+# License: https://github.com/digitalsleuth/xxxswf/blob/master/LICENSE.txt
 # Notes: 
 
 include:


### PR DESCRIPTION
Viper-framework has xxxswf converted to python3, but with a couple of minor bugs which break some features. Due to this, I forked the repo, fixed the bugs, and submitted a pull request to them. In the meantime, I've modified the state to use https://github.com/digitalsleuth/xxxswf instead.

Also, since pylzma was no longer required in python2 form for the original version of xxxswf, I removed it. Added the python3 version of pylzma instead.