### PR TITLE
Added malware-jail

### DIFF
--- a/remnux/tools/init.sls
+++ b/remnux/tools/init.sls
@@ -22,6 +22,7 @@ include:
   - remnux.tools.de4dot
   - remnux.tools.trid
   - remnux.tools.manalyze
+  - remnux.tools.malware-jail
 
 remnux-tools:
   test.nop:
@@ -49,3 +50,4 @@ remnux-tools:
       - sls: remnux.tools.de4dot
       - sls: remnux.tools.trid
       - sls: remnux.tools.manalyze
+      - sls: remnux.tools.malware-jail

--- a/remnux/tools/malware-jail.sls
+++ b/remnux/tools/malware-jail.sls
@@ -1,0 +1,84 @@
+# Name: malware-jail
+# Website: https://github.com/HynekPetrak/malware-jail
+# Description: Nodejs sandbox for semi-automatic JavaScript malware analysis
+# Category: Examine browser malware: JavaScript
+# Author: Hynek Petrak
+# License: https://github.com/HynekPetrak/malware-jail/blob/master/LICENSE
+# Notes: jailme
+
+include:
+  - remnux.packages.git
+  - remnux.packages.npm
+  - remnux.packages.nodejs
+
+remnux-tools-malware-jail-source:
+  git.cloned:
+    - name: https://github.com/hynekpetrak/malware-jail.git
+    - target: /usr/local/malware-jail
+    - user: root
+    - branch: master
+    - require:
+      - sls: remnux.packages.git
+
+remnux-tools-malware-jail-remove-malware:
+  cmd.run:
+    - name: rm -rf malware
+    - cwd: /usr/local/malware-jail
+    - watch:
+      - git: remnux-tools-malware-jail-source
+
+remnux-tools-malware-jail-install:
+  cmd.run:
+    - name: npm install
+    - cwd: /usr/local/malware-jail
+    - require:
+      - sls: remnux.packages.npm
+      - sls: remnux.packages.nodejs
+    - watch:
+      - cmd: remnux-tools-malware-jail-remove-malware
+
+remnux-tools-malware-jail-wrapper:
+  file.managed:
+    - name: /usr/local/bin/jailme
+    - replace: False
+    - mode: 755
+    - contents:
+      - '#!/bin/bash'
+      - node /usr/local/malware-jail/jailme.js ${*}
+    - require:
+      - git: remnux-tools-malware-jail-source
+    - watch:
+      - cmd: remnux-tools-malware-jail-install
+
+remnux-tools-malware-jail-config:
+  file.replace:
+    - name: /usr/local/malware-jail/config.json
+    - pattern: '"env/'
+    - repl: '"/usr/local/malware-jail/env/'
+    - prepend_if_not_found: False
+    - require:
+      - git: remnux-tools-malware-jail-source
+    - watch:
+      - file: remnux-tools-malware-jail-wrapper
+
+remnux-tools-malware-jail-output:
+  file.replace:
+    - name: /usr/local/malware-jail/config.json
+    - pattern: '"output/'
+    - repl: '"/usr/local/malware-jail/output/'
+    - prepend_if_not_found: False
+    - require:
+      - git: remnux-tools-malware-jail-source
+    - watch:
+      - file: remnux-tools-malware-jail-config
+
+remnux-tools-malware-jail-sandbox:
+  file.replace:
+    - name: /usr/local/malware-jail/config.json
+    - pattern: '"sandbox_dump'
+    - repl: '"/usr/local/malware-jail/sandbox_dump'
+    - prepend_if_not_found: False
+    - require:
+      - git: remnux-tools-malware-jail-source
+    - watch:
+      - file: remnux-tools-malware-jail-output


### PR DESCRIPTION
Added malware-jail and a wrapper for it. State also removes the 'malware' directory which comes with a slew of malware samples. Not necessary for the tool to work, so removed them to free up space. Had to use the cmd.run salt command, because file.absent had issues reading some of the non-ascii characters in the filenames.

Tool is designed to be run from the malware-jail directory, which is why the wrapper, and the modification of the config.json file. Added the absolute paths for the required env js files.