### PR TITLE
Added malwoverview

### DIFF
--- a/remnux/python-packages/init.sls
+++ b/remnux/python-packages/init.sls
@@ -54,6 +54,7 @@ include:
   - remnux.python-packages.time-decode
   - remnux.python-packages.pcodedmp
   - remnux.python-packages.droidlysis
+  - remnux.python-packages.malwoverview
 
 remnux-python-packages:
   test.nop:
@@ -113,3 +114,4 @@ remnux-python-packages:
       - sls: remnux.python-packages.time-decode
       - sls: remnux.python-packages.pcodedmp
       - sls: remnux.python-packages.droidlysis
+      - sls: remnux.python-packages.malwoverview

--- a/remnux/python-packages/malwoverview.sls
+++ b/remnux/python-packages/malwoverview.sls
@@ -1,0 +1,37 @@
+# Name: malwoverview
+# Website: https://github.com/digitalsleuth/malwoverview
+# Description: Python 3 tool to query VirusTotal, HybridAnalysis et al.
+# Category: Examine file properties and contents: Hashes
+# Author: Alexandre Borges
+# License: https://github.com/digitalsleuth/malwoverview/blob/master/LICENSE
+# Notes: malwoverview.py, add API keys to ~/.malwapi.conf
+
+{%- set user = salt['pillar.get']('remnux_user', 'remnux') -%}
+
+{% if user != "root" %}
+
+{% set home = "/home/" + user %}
+
+include:
+  - remnux.packages.python-pip
+  - remnux.packages.python3-pip
+  - remnux.packages.git
+
+remnux-python-packages-malwoverview-install:
+  pip.installed:
+    - name: git+https://github.com/digitalsleuth/malwoverview.git
+    - bin_env: /usr/bin/python3
+    - require:
+      - sls: remnux.packages.python3-pip
+      - sls: remnux.packages.git
+
+remnux-python-packages-malwoverview-config-file:
+  file.managed:
+    - name: {{ home }}/.malwapi.conf
+    - user: {{ user }}
+    - group: {{ user }}
+    - makedirs: False
+    - require:
+      - pip: remnux-python-packages-malwoverview-install
+
+{% endif %}


### PR DESCRIPTION
Modified the original source code to repair a few errors and config issues. Instead of editing a .py file which ends up in /usr/lib/python3 etc., I've modified it to read the API's from a config file, and the config file is created by default in the home users directory (of whoever is running the pip installer).
Since the user will be using the cli to identify the desired user for installation, I also added the 'home directory' jinja statement at the top to ensure the proper permissions are set on the .malwapi.conf file stored in the users home directory.

Once testing is completed on the Windows version, I'll be submitting a pull request to the author. 