### PR TITLE
Updated nodejs, tested and fixed box-js

### DIFF
--- a/remnux/node-packages/box-js.sls
+++ b/remnux/node-packages/box-js.sls
@@ -8,25 +8,17 @@
 
 include:
   - remnux.packages.nodejs
-  - remnux.packages.npm
   - remnux.packages.curl
-
-# Sometimes node is not installed, which causes npm.installed to
-# not work, so let's explicitly add the npm package here.
-remnux-node-packages-box-js-npm:
-  pkg.installed:
-    - name: npm
 
 box-js:
   npm.installed:
     - require:
       - sls: remnux.packages.nodejs
-      - sls: remnux.packages.npm
       - sls: remnux.packages.curl
 
 remnux-node-packages-box-export-shebang:
   file.replace:
-    - name: /usr/local/bin/box-export
+    - name: /usr/bin/box-export
     - pattern: '#!/usr/bin/env node'
     - repl: '#!/usr/bin/env node'
     - prepend_if_not_found: True
@@ -34,3 +26,24 @@ remnux-node-packages-box-export-shebang:
     - require:
       - npm: box-js
 
+remnux-node-packages-box-export-version:
+  file.replace:
+    - name: /usr/bin/box-export
+    - pattern: ./package.json
+    - repl: ../../package.json
+    - count: 1
+    - require:
+      - npm: box-js
+    - watch:
+      - file: remnux-node-packages-box-export-shebang
+
+remnux-node-packages-box-export-license:
+  file.replace:
+    - name: /usr/bin/box-export
+    - pattern: /LICENSE
+    - repl: /../../LICENSE
+    - count: 1
+    - require:
+      - npm: box-js
+    - watch:
+      - file: remnux-node-packages-box-export-version

--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -129,7 +129,6 @@ include:
   - remnux.packages.edb-debugger
   - remnux.packages.xorstrings
   - remnux.packages.nodejs
-  - remnux.packages.npm
   - remnux.packages.python3-tk
   - remnux.packages.nautilus
   - remnux.packages.postgresql
@@ -292,7 +291,6 @@ remnux-packages:
       - sls: remnux.packages.edb-debugger
       - sls: remnux.packages.xorstrings
       - sls: remnux.packages.nodejs
-      - sls: remnux.packages.npm
       - sls: remnux.packages.python3-tk
       - sls: remnux.packages.nautilus
       - sls: remnux.packages.postgresql

--- a/remnux/packages/nodejs.sls
+++ b/remnux/packages/nodejs.sls
@@ -1,2 +1,5 @@
+include:
+  - remnux.repos.nodejs
+
 nodejs:
   pkg.installed

--- a/remnux/packages/npm.sls
+++ b/remnux/packages/npm.sls
@@ -1,2 +1,0 @@
-npm:
-  pkg.installed

--- a/remnux/repos/init.sls
+++ b/remnux/repos/init.sls
@@ -10,6 +10,7 @@ include:
   - remnux.repos.wireshark-dev
   - remnux.repos.microsoft
   - remnux.repos.microsoft-vscode
+  - remnux.repos.nodejs
 
 remnux-repos:
   test.nop:
@@ -25,3 +26,4 @@ remnux-repos:
       - sls: remnux.repos.wireshark-dev
       - sls: remnux.repos.microsoft
       - sls: remnux.repos.microsoft-vscode
+      - sls: remnux.repos.nodejs

--- a/remnux/repos/nodejs.sls
+++ b/remnux/repos/nodejs.sls
@@ -1,0 +1,8 @@
+nodejs-repo:
+  pkgrepo.managed:
+    - humanname: nodejs
+    - name: deb https://deb.nodesource.com/node_14.x bionic main
+    - file: /etc/apt/sources.list.d/nodesource.list
+    - key_url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    - gpgcheck: 1
+    - refresh: true


### PR DESCRIPTION
box-export threw errors on -v and --license (not nodejs related, code related). Corrected path locations for those commands. Updated nodejs to fetch version 14.x from nodesource vice version 8.x from Ubuntu repo.
Tested box-js and box-export with new node version, no issues. 
Submitted pull request to CapacitorSet (box-js author) to correct the box-export shebang and the path issues referenced above.