### PR TITLE
Moved vipermonkey to a venv

### DIFF
--- a/remnux/python-packages/vipermonkey.sls
+++ b/remnux/python-packages/vipermonkey.sls
@@ -1,19 +1,42 @@
 # Name: ViperMonkey
 # Website: https://www.decalage.info/en/vba_emulation
 # Description: A VBA parser and emulation engine to analyze malicious macros
-# Category: Analyze Documents: Microsoft Office
-# Author: Philippe Lagadec: https://twitter.com/decalage2
-# License: Free, custom license: https://github.com/decalage2/ViperMonkey#license
+# Category: Examine document files: Microsoft Office
+# Author: Philippe Lagadec
+# License: https://github.com/decalage2/ViperMonkey#license
 # Notes: vmonkey
 
 include:
   - remnux.packages.python-pip
   - remnux.packages.git
+  - remnux.packages.virtualenv
 
-remnux-pip-vipermonkey:
-  pip.installed:
-    - name: git+https://github.com/decalage2/ViperMonkey.git
+remnux-python-packages-vipermonkey-virtualenv:
+  virtualenv.managed:
+    - name: /opt/vipermonkey
+    - venv_bin: /usr/bin/virtualenv
+    - python: /usr/bin/python
+    - pip_pkgs:
+      - pip
+      - setuptools
+      - wheel
     - require:
       - sls: remnux.packages.python-pip
+      - sls: remnux.packages.virtualenv
+
+remnux-python-packages-vipermonkey-install:
+  pip.installed:
+    - name: git+https://github.com/decalage2/ViperMonkey.git
+    - bin_env: /opt/vipermonkey/bin/python
+    - require:
       - sls: remnux.packages.git
+      - sls: remnux.packages.python-pip
+      - virtualenv: remnux-python-packages-vipermonkey-virtualenv
+
+remnux-python-packages-vipermonkey-symlink:
+  file.symlink:
+    - name: /usr/local/bin/vmonkey
+    - target: /opt/vipermonkey/bin/vmonkey
+    - require:
+      - pip: remnux-python-packages-vipermonkey-install
 

--- a/remnux/python-packages/vipermonkey.sls
+++ b/remnux/python-packages/vipermonkey.sls
@@ -1,9 +1,9 @@
 # Name: ViperMonkey
 # Website: https://www.decalage.info/en/vba_emulation
 # Description: A VBA parser and emulation engine to analyze malicious macros
-# Category: Examine document files: Microsoft Office
-# Author: Philippe Lagadec
-# License: https://github.com/decalage2/ViperMonkey#license
+# Category: Analyze Documents: Microsoft Office
+# Author: Philippe Lagadec: https://twitter.com/decalage2
+# License: Free, custom license: https://github.com/decalage2/ViperMonkey#license
 # Notes: vmonkey
 
 include:


### PR DESCRIPTION
Moved vipermonkey to a virtualenv to fix an oletools/olefile requirement issue between python2 and python3.
Noticed the header incongruities after the initial pull. Fixed those after the fact.