### PR TITLE
More 3001 compatible states

### DIFF
--- a/remnux/python-packages/pypdns.sls
+++ b/remnux/python-packages/pypdns.sls
@@ -2,14 +2,16 @@
 # Website: https://github.com/CIRCL/PyPDNS
 # Description: Python library to query passive DNS services that follow the Passive DNS - Common Output Format
 # Category: Gather and Analyze Data
-# Author: Raphaël Vinot, Alexandre Dulaunoy, CIRCL - Computer Incident Response Center Luxembourg
+# Author: Raphael Vinot, Alexandre Dulaunoy, CIRCL - Computer Incident Response Center Luxembourg
 # License: Free, custom license: https://github.com/CIRCL/PyPDNS/blob/master/LICENSE
 # Notes: 
 
 include:
   - remnux.packages.python-pip
+  - remnux.packages.python3-pip
 
 pypdns:
   pip.installed:
+    - bin_env: /usr/bin/python
     - require:
       - sls: remnux.packages.python-pip

--- a/remnux/python-packages/pype32.sls
+++ b/remnux/python-packages/pype32.sls
@@ -1,7 +1,9 @@
 include:
   - remnux.packages.python-pip
+  - remnux.packages.python3-pip
 
 pype32:
   pip.installed:
+    - bin_env: /usr/bin/python
     - require:
       - sls: remnux.packages.python-pip

--- a/remnux/python-packages/pypssl.sls
+++ b/remnux/python-packages/pypssl.sls
@@ -1,7 +1,9 @@
 include:
   - remnux.packages.python-pip
+  - remnux.packages.python3-pip
 
 pypssl:
   pip.installed:
+    - bin_env: /usr/bin/python
     - require:
       - sls: remnux.packages.python-pip

--- a/remnux/python-packages/pysocks.sls
+++ b/remnux/python-packages/pysocks.sls
@@ -1,8 +1,10 @@
 include:
   - remnux.packages.python-pip
+  - remnux.packages.python3-pip
 
 pysocks:
   pip.installed:
+    - bin_env: /usr/bin/python
     - name: pysocks
     - require:
       - pkg: python-pip

--- a/remnux/python-packages/pytesseract.sls
+++ b/remnux/python-packages/pytesseract.sls
@@ -1,13 +1,10 @@
 include:
   - remnux.packages.python3-pip
-  - remnux.packages.python3
   - remnux.packages.python-pip
 
-remnux-pytesseract:
+pytesseract:
   pip.installed:
-    - name: pytesseract
-    - bin_env: /usr/bin/pip3
+    - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
       - sls: remnux.packages.python3-pip
-      - sls: remnux.packages.python-pip


### PR DESCRIPTION
Adding pypdns, pype32, pypssl, pysocks, and pytesseract. Pyperclip was already 3001 compatible, no changes required.