### PR TITLE
3001 update2

### DIFF
--- a/remnux/python-packages/balbuzard.sls
+++ b/remnux/python-packages/balbuzard.sls
@@ -9,9 +9,11 @@
 include:
   - remnux.packages.python-pip
   - remnux.python-packages.yara-python
+  - remnux.packages.python3-pip
 
 remnux-python-packages-balbuzard:
   pip.installed:
+    - bin_env: /usr/bin/python
     - name: balbuzard
     - require:
       - sls: remnux.packages.python-pip

--- a/remnux/python-packages/dpapick.sls
+++ b/remnux/python-packages/dpapick.sls
@@ -3,11 +3,12 @@ include:
   - remnux.packages.python-pip
   - remnux.packages.python-m2crypto
   - remnux.python-packages.m2crypto
+  - remnux.packages.python3-pip
 
 dpapick:
   pip.installed:
     - name: dpapick
-    - pip_bin: /usr/bin/pip
+    - bin_env: /usr/bin/python
     - upgrade: True
     - require:
       - sls: remnux.packages.libssl-dev

--- a/remnux/python-packages/droidlysis.sls
+++ b/remnux/python-packages/droidlysis.sls
@@ -18,7 +18,7 @@ include:
 remnux-python-packages-droidlysis:
   pip.installed:
     - name: droidlysis
-    - bin_env: /usr/bin/pip3
+    - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.tools.apktool
       - sls: remnux.packages.baksmali

--- a/remnux/python-packages/fakemail.sls
+++ b/remnux/python-packages/fakemail.sls
@@ -15,6 +15,5 @@ remnux-pip-fakemail:
     - name: fakemail
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python-pip
       - sls: remnux.packages.python3-pip
 

--- a/remnux/python-packages/frida.sls
+++ b/remnux/python-packages/frida.sls
@@ -2,7 +2,7 @@
 # Website: https://frida.re
 # Description: Trace the execution of a process to analyze its behavior.
 # Category: Dynamically Reverse-Engineer Code: General
-# Author: Ole André Vadla Ravnås
+# Author: Ole Andre Vadla Ravnas
 # License: wxWindows Library License 3.1: https://github.com/frida/frida/blob/master/COPYING
 # Notes: frida, frida-ps, frida-trace, frida-discover, frida-ls-devices, frida-kill
 

--- a/remnux/python-packages/init.sls
+++ b/remnux/python-packages/init.sls
@@ -19,7 +19,6 @@ include:
   - remnux.python-packages.pypdns
   - remnux.python-packages.pypssl
   - remnux.python-packages.r2pipe
-  - remnux.python-packages.rarfile
   - remnux.python-packages.requesocks
   - remnux.python-packages.setuptools
   - remnux.python-packages.shodan
@@ -82,7 +81,6 @@ remnux-python-packages:
       - sls: remnux.python-packages.pypdns
       - sls: remnux.python-packages.pypssl
       - sls: remnux.python-packages.r2pipe
-      - sls: remnux.python-packages.rarfile
       - sls: remnux.python-packages.requesocks
       - sls: remnux.python-packages.setuptools
       - sls: remnux.python-packages.shodan

--- a/remnux/python-packages/init.sls
+++ b/remnux/python-packages/init.sls
@@ -57,6 +57,7 @@ include:
   - remnux.python-packages.stringsifter
   - remnux.python-packages.vivisect
   - remnux.python-packages.oletools
+  - remnux.python-packages.pycryptodomex
 
 remnux-python-packages:
   test.nop:
@@ -119,3 +120,4 @@ remnux-python-packages:
       - sls: remnux.python-packages.stringsifter
       - sls: remnux.python-packages.vivisect
       - sls: remnux.python-packages.oletools
+      - sls: remnux.python-packages.pycryptodomex

--- a/remnux/python-packages/ioc-writer.sls
+++ b/remnux/python-packages/ioc-writer.sls
@@ -9,9 +9,11 @@
 include:
   - remnux.packages.python-pip
   - remnux.python-packages.lxml
+  - remnux.packages.python3-pip
 
 ioc_writer:
   pip.installed:
+    - bin_env: /usr/bin/python
     - require:
       - pkg: python-pip
-      - pip: lxml
+      - sls: remnux.python-packages.lxml

--- a/remnux/python-packages/pycryptodomex.sls
+++ b/remnux/python-packages/pycryptodomex.sls
@@ -2,8 +2,9 @@ include:
   - remnux.packages.python-pip
   - remnux.packages.python3-pip
 
-rarfile:
+pycryptodomex:
   pip.installed:
     - bin_env: /usr/bin/python3
+    - name: pycryptodomex == 3.7.3
     - require:
       - sls: remnux.packages.python3-pip

--- a/remnux/python-packages/pyzipper.sls
+++ b/remnux/python-packages/pyzipper.sls
@@ -1,10 +1,12 @@
 include:
   - remnux.packages.python3-pip
   - remnux.packages.python-pip
+  - remnux.python-packages.pycryptodomex
 
 remnux-python-packages-pyzipper:
   pip.installed:
     - name: pyzipper
-    - bin_env: /usr/bin/pip3
+    - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.packages.python3-pip
+      - sls: remnux.python-packages.pycryptodomex

--- a/remnux/python-packages/r2pipe.sls
+++ b/remnux/python-packages/r2pipe.sls
@@ -1,7 +1,9 @@
 include:
   - remnux.packages.python-pip
+  - remnux.packages.python3-pip
 
 r2pipe:
   pip.installed:
+    - bin_env: /usr/bin/python
     - require:
       - sls: remnux.packages.python-pip

--- a/remnux/python-packages/rarfile.sls
+++ b/remnux/python-packages/rarfile.sls
@@ -1,9 +1,0 @@
-include:
-  - remnux.packages.python-pip
-  - remnux.packages.python3-pip
-
-rarfile:
-  pip.installed:
-    - bin_env: /usr/bin/python3
-    - require:
-      - sls: remnux.packages.python3-pip

--- a/remnux/python-packages/requesocks.sls
+++ b/remnux/python-packages/requesocks.sls
@@ -1,7 +1,9 @@
 include:
   - remnux.packages.python-pip
+  - remnux.packages.python3-pip
 
 requesocks:
   pip.installed:
+    - bin_env: /usr/bin/python
     - require:
       - sls: remnux.packages.python-pip

--- a/remnux/python-packages/setuptools.sls
+++ b/remnux/python-packages/setuptools.sls
@@ -1,8 +1,10 @@
 include:
   - remnux.packages.python-pip
+  - remnux.packages.python3-pip
 
 setuptools:
   pip.installed:
+    - bin_env: /usr/bin/python
     - upgrade: True
     - require:
       - sls: remnux.packages.python-pip

--- a/remnux/python-packages/shodan.sls
+++ b/remnux/python-packages/shodan.sls
@@ -8,8 +8,10 @@
 
 include:
   - remnux.packages.python-pip
+  - remnux.packages.python3-pip
 
 shodan:
   pip.installed:
+    - bin_env: /usr/bin/python
     - require:
       - sls: remnux.packages.python-pip

--- a/remnux/python-packages/simplejson.sls
+++ b/remnux/python-packages/simplejson.sls
@@ -1,7 +1,9 @@
 include:
   - remnux.packages.python-pip
+  - remnux.packages.python3-pip
 
 simplejson:
   pip.installed:
+    - bin_env: /usr/bin/python
     - require:
       - sls: remnux.packages.python-pip

--- a/remnux/python-packages/six.sls
+++ b/remnux/python-packages/six.sls
@@ -1,8 +1,10 @@
 include:
   - remnux.packages.python-pip
+  - remnux.packages.python3-pip
 
 six:
   pip.installed:
+    - bin_env: /usr/bin/python
     - name: six >= 1.6
     - upgrade: True
     - require:

--- a/remnux/python-packages/stpyv8.sls
+++ b/remnux/python-packages/stpyv8.sls
@@ -7,8 +7,6 @@
 # Notes: 
 
 include:
-  - remnux.packages.python3
-  - remnux.packages.python
   - remnux.packages.sudo
   - remnux.packages.libboost-python-dev
   - remnux.packages.libboost-system-dev
@@ -24,7 +22,6 @@ remnux-pip3-stpyv8:
     - name: https://github.com/area1/stpyv8/releases/download/v8.3.110.13/stpyv8-8.3.110.13-cp36-cp36m-linux_x86_64.whl
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3
       - sls: remnux.packages.python3-pip
       - sls: remnux.packages.sudo
       - sls: remnux.packages.libboost-python-dev

--- a/remnux/python-packages/thug.sls
+++ b/remnux/python-packages/thug.sls
@@ -8,7 +8,6 @@
 
 include:
   - remnux.packages.git
-  - remnux.packages.python3
   - remnux.packages.python3-setuptools
   - remnux.packages.python3-pip
   - remnux.packages.libemu
@@ -32,10 +31,9 @@ remnux-git-thug:
 remnux-pip3-install-thug:
   pip.installed:
     - name: thug
-    - bin_env: /usr/bin/pip3
+    - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.packages.python3-pip
-      - sls: remnux.packages.python-pip
     - watch:
       - git: remnux-git-thug
 

--- a/remnux/python-packages/unicode.sls
+++ b/remnux/python-packages/unicode.sls
@@ -16,5 +16,4 @@ remnux-pip-unicode:
     - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.packages.python3-pip
-      - sls: remnux.packages.python-pip
 

--- a/remnux/python-packages/vipermonkey.sls
+++ b/remnux/python-packages/vipermonkey.sls
@@ -10,6 +10,7 @@ include:
   - remnux.packages.python-pip
   - remnux.packages.git
   - remnux.packages.virtualenv
+  - remnux.packages.python3-pip
 
 remnux-python-packages-vipermonkey-virtualenv:
   virtualenv.managed:

--- a/remnux/python-packages/vivisect.sls
+++ b/remnux/python-packages/vivisect.sls
@@ -11,9 +11,11 @@ include:
   - remnux.packages.python-pip
   - remnux.packages.python-pyqt5
   - remnux.packages.python-pyqt5-qtwebkit
+  - remnux.packages.python3-pip
 
 remnux-pip-vivisect:
   pip.installed:
+    - bin_env: /usr/bin/python
     - name: https://github.com/williballenthin/vivisect/zipball/master
     - require:
       - sls: remnux.packages.git

--- a/remnux/python-packages/volatility.sls
+++ b/remnux/python-packages/volatility.sls
@@ -25,11 +25,12 @@ include:
   - remnux.python-packages.pysocks
   - remnux.python-packages.simplejson
   - remnux.python-packages.yara-python
+  - remnux.packages.python3-pip
 
 remnux-python-packages-volatility:
   pip.installed:
     - name: git+https://github.com/volatilityfoundation/volatility.git@2.6.1
-    - pip_bin: /usr/bin/pip
+    - bin_env: /usr/bin/python
     - require:
       - sls: remnux.packages.git
       - sls: remnux.packages.python-pip

--- a/remnux/python-packages/volatility3.sls
+++ b/remnux/python-packages/volatility3.sls
@@ -15,10 +15,9 @@ include:
 remnux-python-packages-volatility3:
   pip.installed:
     - name: git+https://github.com/volatilityfoundation/volatility3.git@master
-    - pip_bin: /usr/bin/python3
+    - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.packages.git
-      - sls: remnux.packages.python-pip
       - sls: remnux.packages.python3-pip
       - sls: remnux.python-packages.pefile
 

--- a/remnux/python-packages/wheel.sls
+++ b/remnux/python-packages/wheel.sls
@@ -1,7 +1,9 @@
 include:
   - remnux.packages.python-pip
+  - remnux.packages.python3-pip
 
 wheel:
   pip.installed:
+    - bin_env: /usr/bin/python
     - require:
       - sls: remnux.packages.python-pip

--- a/remnux/python-packages/xlmmacrodeobfuscator.sls
+++ b/remnux/python-packages/xlmmacrodeobfuscator.sls
@@ -16,7 +16,6 @@ remnux-pip-xlmmacrodeobfuscator:
     - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.packages.python3-pip
-      - sls: remnux.packages.python-pip
 
 /usr/local/bin/runxlrd2.py:
   file.managed:

--- a/remnux/python-packages/xortool.sls
+++ b/remnux/python-packages/xortool.sls
@@ -12,7 +12,6 @@ include:
 
 xortool:
   pip.installed:
-    - pip_bin: /usr/bin/python3
+    - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python-pip
       - sls: remnux.packages.python3-pip

--- a/remnux/python-packages/yara-python.sls
+++ b/remnux/python-packages/yara-python.sls
@@ -1,7 +1,9 @@
 include:
   - remnux.packages.python-pip
+  - remnux.packages.python3-pip
 
 yara-python:
   pip.installed:
+    - bin_env: /usr/bin/python
     - require:
       - sls: remnux.packages.python-pip


### PR DESCRIPTION
Several python-packages updated. Removed rarfile (no longer required).
Had to update headers for some states to remove unicode 'ascii' values (circumflex, character accents) as Salt 3001 does not parse these characters properly in a YAML context.
Modified packages for proper bin_env: /usr/bin/python(3) context as well, to avoid pinning to 'pip'. 
Salt 3001 comes with pycryptodomex 3.4.8, however Salt 3000 does not come with it at all. Due to this, pyzipper (which requires pycryptodomex 3.7.3+ but does not directly specify version), failed import. Added pycryptodomex, pinned to 3.7.3 at this time.
