### PR TITLE
Overhaul of viper-framework

### DIFF
--- a/.ci/dev-state.sh
+++ b/.ci/dev-state.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-DISTRO=${DISTRO:="bionic3001"}
+DISTRO=${DISTRO:="bionic"}
 STATE=$1
 
 docker run -it --rm --name="remnux-state-${STATE}" -v `pwd`/remnux:/srv/salt/remnux --cap-add SYS_ADMIN remnux/saltstack-tester:${DISTRO} \

--- a/remnux/python-packages/viper-framework.sls
+++ b/remnux/python-packages/viper-framework.sls
@@ -48,48 +48,23 @@ remnux-python-packages-viper-install:
 
 remnux-python-packages-viper-requirements:
   pip.installed:
-    - pkgs:
-      - androguard==3.3.5
-      - pyclamd==0.4.0
-      - pypdns==1.4.1
-      - pyelftools==0.25
-      - dnspython==1.16.0
-      - olefile==0.46
-      - git+https://github.com/viper-framework/xxxswf.git@9188316eb7a179326d99bfde9fe0184bb3cee6a3#egg=xxxswf
-      - pyparsing==2.4.7
-      - packaging==19.0
-      - pefile==2019.4.18
-      - bitstring==3.1.7
-      - pyasn1==0.4.8
-      - pyopenssl==19.1.0
-      - cryptography==2.9.2
-      - cffi==1.14.0
-      - asn1crypto==1.3.0
-      - idna==2.9
-      - ipaddress==1.0.23
-      - pycparser==2.20
-      - pypssl==2.1
-      - r2pipe==1.2.0
-      - beautifulsoup4==4.7.1
-      - pylzma==0.5.0
-      - virustotal-api==1.1.10
-      - yara-python==3.10.0
-      - pycrypto==2.6.1
-      - git+https://github.com/viper-framework/ScrapySplashWrapper.git#egg=ScrapySplashWrapper
-      - git+https://github.com/sebdraven/verify-sigs.git#egg=verify-sigs
-      - oletools==0.54.1
-      - git+https://github.com/MISP/PyTaxonomies.git#egg=PyTaxonomies
-      - git+https://github.com/MISP/PyMISPGalaxies.git#egg=PyMISPGalaxies
-      - ocrd-pyexiftool==0.2.0
-      - jbxapi>=3.1.3,<4
-      - pymisp[fileobjects,virustotal] >= 2.4.96
-      - jsonschema<4.0.0,>=3.2.0
-      - lief==0.10.1
-      - snoopdroid==2.1
-    - bin_env: /opt/viper/bin/python3
+    - name: jsonschema<4.0.0,>=3.2.0
+    - editable: git+https://github.com/viper-framework/xxxswf.git@9188316eb7a179326d99bfde9fe0184bb3cee6a3#egg=xxxswf
+    - editable: git+https://github.com/viper-framework/ScrapySplashWrapper.git#egg=ScrapySplashWrapper
+    - editable: git+https://github.com/sebdraven/verify-sigs.git#egg=verify-sigs
+    - editable: git+https://github.com/MISP/PyTaxonomies.git#egg=PyTaxonomies
+    - editable: git+https://github.com/MISP/PyMISPGalaxies.git#egg=PyMISPGalaxies
+    - requirements: https://github.com/viper-framework/viper-modules/raw/master/requirements.txt
+    - bin_env: /opt/viper/bin/pip3
+
+remnux-python-packages-viper-update-fix:
+  file.replace:
+    - name: /opt/viper/lib/python3.6/site-packages/viper/core/ui/cmd/update-modules.py
+    - pattern: pip3
+    - repl: /opt/viper/bin/pip3
+    - count: 1
+    - prepend_if_not_found: False
     - require:
-      - pip: remnux-python-packages-viper-install
-    - watch:
       - pip: remnux-python-packages-viper-install
 
 remnux-python-packages-viper-symlink:


### PR DESCRIPTION
Due to some of the changes in salt 3001, and some changes at the viper-framework repo (regarding requirements), many changes had to be made to the viper-framework state. All of the requirements will now be installed from a requirements.txt on the viper-modules repo (to remain up-to-date). Additionally, the change of 'editable' to the git+ egg installations should resolve any 'ERROR' entries in the saltstack log.

The update-modules feature in viper would, by default, only call pip3 (system default) and not the venv pip3. Added an entry to modifiy the pip3 entry in the update-modules section of the tool.
User will need to run update-modules at least once for the already installed packages to register as modules in the .viper/modules directory in the users folder. This is unavoidable, as this is the design of the tool.
