### PR TITLE
Modified permissions for viper virtualenv, viper-framework state fix

### DIFF
--- a/remnux/config/init.sls
+++ b/remnux/config/init.sls
@@ -16,6 +16,7 @@ include:
   - remnux.config.binee
   - remnux.config.nginx
   - remnux.config.android-project-creator
+  - remnux.config.viper-virtualenv
 
 remnux-config:
   test.nop:
@@ -37,3 +38,4 @@ remnux-config:
       - sls: remnux.config.binee
       - sls: remnux.config.nginx
       - sls: remnux.config.android-project-creator
+      - sls: remnux.config.viper-virtualenv

--- a/remnux/config/viper-virtualenv.sls
+++ b/remnux/config/viper-virtualenv.sls
@@ -1,0 +1,21 @@
+{% set user = salt['pillar.get']('remnux_user', 'remnux') %}
+
+include:
+  - remnux.config.user
+  - remnux.python-packages.viper-framework
+
+remnux-config-viper-framework-virtualenv-permissions:
+  file.directory:
+    - name: /opt/viper
+    - makedirs: False
+    - user: {{ user }}
+    - group: {{ user }}
+    - mode: 755
+    - recurse:
+      - user
+      - group
+      - mode
+    - require:
+      - user: remnux-user-{{ user }}
+    - require:
+      - sls: remnux.python-packages.viper-framework

--- a/remnux/python-packages/viper-framework.sls
+++ b/remnux/python-packages/viper-framework.sls
@@ -60,8 +60,8 @@ remnux-python-packages-viper-requirements:
 remnux-python-packages-viper-update-fix:
   file.replace:
     - name: /opt/viper/lib/python3.6/site-packages/viper/core/ui/cmd/update-modules.py
-    - pattern: pip3
-    - repl: /opt/viper/bin/pip3
+    - pattern: "pip3"
+    - repl: "/opt/viper/bin/pip3"
     - count: 1
     - prepend_if_not_found: False
     - require:


### PR DESCRIPTION
Pattern replacement in viper-framework state was too broad. Added the viper-virtualenv config state to set permissions on /opt/viper to add the running user so update-modules could be run without sudo.
