### PR TITLE
Substantial update to viper-framework

### DIFF
--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -165,6 +165,7 @@ include:
   - remnux.packages.nano
   - remnux.packages.file
   - remnux.packages.android-project-creator
+  - remnux.packages.libdpkg-perl
 
 remnux-packages:
   test.nop:
@@ -333,3 +334,4 @@ remnux-packages:
       - sls: remnux.packages.nano
       - sls: remnux.packages.file
       - sls: remnux.packages.android-project-creator
+      - sls: remnux.packages.libdpkg-perl

--- a/remnux/packages/libdpkg-perl.sls
+++ b/remnux/packages/libdpkg-perl.sls
@@ -1,0 +1,2 @@
+libdpkg-perl:
+  pkg.installed

--- a/remnux/python-packages/viper-framework.sls
+++ b/remnux/python-packages/viper-framework.sls
@@ -4,9 +4,18 @@
 # Category: Gather and Analyze Data
 # Author: Claudio Guarnieri: https://nex.sx
 # License: BSD 3-Clause License: https://github.com/viper-framework/viper/blob/master/LICENSE
-# Notes: Run the tool using the `viper` command. The first time you activate the tool, specify the `update-modules` command within it to download and update community modules from the tool's repository.
+# Notes: viper
+
+{%- set user = salt['pillar.get']('remnux_user', 'remnux') -%}
+
+{%- if user == "root" -%}
+  {%- set home = "/root" -%}
+{%- else -%}
+  {%- set home = "/home/" + user -%}
+{% endif %}
 
 include:
+  - remnux.config.user
   - remnux.packages.libssl-dev
   - remnux.packages.swig
   - remnux.packages.libusb-1
@@ -17,6 +26,15 @@ include:
   - remnux.packages.python3-pip
   - remnux.packages.python3-virtualenv
   - remnux.packages.python3-venv
+  - remnux.packages.build-essential
+  - remnux.packages.libffi-dev
+  - remnux.packages.unrar
+  - remnux.packages.p7zip-full
+  - remnux.packages.tor
+  - remnux.packages.clamav-daemon
+  - remnux.packages.ssdeep
+  - remnux.packages.libdpkg-perl
+  - remnux.perl-packages.exiftool
 
 remnux-python-packages-viper-virtualenv:
   virtualenv.managed:
@@ -44,33 +62,106 @@ remnux-python-packages-viper-install:
       - sls: remnux.packages.libfuzzy-dev
       - sls: remnux.packages.git
       - sls: remnux.packages.python3-pip
+      - sls: remnux.packages.build-essential
+      - sls: remnux.packages.libffi-dev
+      - sls: remnux.packages.unrar
+      - sls: remnux.packages.p7zip-full
+      - sls: remnux.packages.tor
+      - sls: remnux.packages.clamav-daemon
+      - sls: remnux.packages.ssdeep
+      - sls: remnux.packages.libdpkg-perl
+      - sls: remnux.perl-packages.exiftool
       - virtualenv: remnux-python-packages-viper-virtualenv
-
-remnux-python-packages-viper-requirements:
-  pip.installed:
-    - name: jsonschema<4.0.0,>=3.2.0
-    - editable: git+https://github.com/viper-framework/xxxswf.git@9188316eb7a179326d99bfde9fe0184bb3cee6a3#egg=xxxswf
-    - editable: git+https://github.com/viper-framework/ScrapySplashWrapper.git#egg=ScrapySplashWrapper
-    - editable: git+https://github.com/sebdraven/verify-sigs.git#egg=verify-sigs
-    - editable: git+https://github.com/MISP/PyTaxonomies.git#egg=PyTaxonomies
-    - editable: git+https://github.com/MISP/PyMISPGalaxies.git#egg=PyMISPGalaxies
-    - requirements: https://github.com/viper-framework/viper-modules/raw/master/requirements.txt
-    - bin_env: /opt/viper/bin/pip3
 
 remnux-python-packages-viper-update-fix:
   file.replace:
     - name: /opt/viper/lib/python3.6/site-packages/viper/core/ui/cmd/update-modules.py
-    - pattern: "pip3"
-    - repl: "/opt/viper/bin/pip3"
+    - pattern: '"pip3", "install"'
+    - repl: '"/opt/viper/bin/pip3", "install"'
     - count: 1
     - prepend_if_not_found: False
     - require:
       - pip: remnux-python-packages-viper-install
+
+remnux-python-packages-viper-directory:
+  file.directory:
+    - name: {{ home }}/.viper
+    - makedirs: True
+    - user: {{ user }}
+    - group: {{ user }}
+    - recurse:
+      - user
+      - group
+    - require:
+      - pip: remnux-python-packages-viper-install
+
+remnux-python-packages-viper-modules-git:
+  git.cloned:
+    - name: https://github.com/viper-framework/viper-modules.git
+    - target: {{ home }}/.viper/modules
+    - user: {{ user }}
+    - require:
+      - file: remnux-python-packages-viper-directory
+
+remnux-python-packages-viper-modules-verify-sigs:
+  file.replace:
+    - name: {{ home }}/.viper/modules/requirements.txt
+    - pattern: 'verify-sigs @ '
+    - repl: ''
+    - count: 1
+    - prepend_if_not_found: False
+    - require:
+      - git: remnux-python-packages-viper-modules-git
+
+remnux-python-packages-viper-modules-pymispgalaxies:
+  file.replace:
+    - name: {{ home }}/.viper/modules/requirements.txt
+    - pattern: 'PyMISPGalaxies @ '
+    - repl: ''
+    - count: 1
+    - prepend_if_not_found: False
+    - require:
+      - git: remnux-python-packages-viper-modules-git
+
+remnux-python-packages-viper-modules-init:
+  cmd.run:
+    - name: git submodule init
+    - cwd: {{ home }}/.viper/modules
+    - require:
+      - git: remnux-python-packages-viper-modules-git
+
+remnux-python-packages-viper-modules-update:
+  cmd.run:
+    - name: git submodule update
+    - cwd: {{ home }}/.viper/modules
+    - require:
+      - git: remnux-python-packages-viper-modules-git
+
+remnux-python-packages-viper-modules-requirements:
+  pip.installed:
+    - requirements: {{ home }}/.viper/modules/requirements.txt
+    - upgrade: True
+    - bin_env: /opt/viper/bin/pip3
+    - require:
+      - file: remnux-python-packages-viper-modules-verify-sigs
+      - file: remnux-python-packages-viper-modules-pymispgalaxies
 
 remnux-python-packages-viper-symlink:
   file.symlink:
     - name: /usr/local/bin/viper
     - target: /opt/viper/bin/viper
     - force: true
+    - require:
+      - pip: remnux-python-packages-viper-install
+
+remnux-python-packages-viper-venv-directory:
+  file.directory:
+    - name: /opt/viper
+    - makedirs: False
+    - user: {{ user }}
+    - group: {{ user }}
+    - recurse:
+      - user
+      - group
     - require:
       - pip: remnux-python-packages-viper-install


### PR DESCRIPTION
Added libdpkg-perl as a requirement for a plugin for viper-framework. Also, included additional packages which support plugins for viper-framework which, technically get installed anyways, however in order to make this a complete independent state, they are included here.
State now completes a manual installation consisting of the goal of the 'update-modules' command in viper. This makes viper-framework completely configured to run without requiring an update-modules command, and avoiding any potential error messages caused.
Due to the specific format of some of the python requirements in the requirements.txt file, a few minor changes had to be made. Also, permissions had to be set on the /opt/viper directory for ownership of the user in order for pip to properly update the python requirements when running 'update-modules' in viper, which does not support running this command with sudo.

This state adds between 15-30 seconds to the previous install time, but is roughly the same footprint in size as the previous state (both accomplish the same goal, however this one downloads the 'modules' directory directly from github, approx 2.5 MB).
The docker for this will be submitted shortly, which will be formatted in a similar fashion to this, but without the virtualenv.
