### PR TITLE
Droidlysis fixes for conf files

### DIFF
--- a/remnux/python-packages/droidlysis.sls
+++ b/remnux/python-packages/droidlysis.sls
@@ -4,7 +4,7 @@
 # Category: Statically Analyze Code: Android, Examine Static Properties: General
 # Author: cryptax
 # License: MIT License: https://github.com/cryptax/droidlysis/blob/master/LICENSE
-# Notes: droidlysis3.py
+# Notes: droidlysis
 
 include:
   - remnux.packages.python3-pip
@@ -63,16 +63,6 @@ remnux-python-packages-droidlysis-droidconfig-set4:
     - name: /usr/local/lib/python3.6/dist-packages/droidconfig.py
     - pattern: '^PROCYON_JAR.*$'
     - repl: 'PROCYON_JAR = os.path.join(os.path.expanduser("/usr/share/java"), "procyon-decompiler-0.5.32.jar")'
-    - prepend_if_not_found: False
-    - count: 1
-    - require:
-      - pip: remnux-python-packages-droidlysis
-
-remnux-python-packages-droidlysis-droidconfig-set5:
-  file.replace:
-    - name: /usr/local/lib/python3.6/dist-packages/droidconfig.py
-    - pattern: '^INSTALL_DIR.*$'
-    - repl: 'INSTALL_DIR = os.path.expanduser("/usr/local/bin")'
     - prepend_if_not_found: False
     - count: 1
     - require:


### PR DESCRIPTION
Updated the header to read 'Notes: droidlysis' vice 'droidlysis3.py' since this is the new method to call the program. But the biggest change was to remove the modification to the INSTALL_DIR. With the previous change, the tool was unable to detect the conf/ directory which contains the .conf files.

Removing the INSTALL_DIR returns the default installation to /usr/local/lib/python3.6/dist-packages and the conf files then get detected from here (since they're located in the /usr/local/lib/python3.6/dist-packages/conf directory). The droidlysis file in /usr/local/bin is not actually the install directory, but merely a wrapper.

Tested successfully with the Signal apk (as recommended by cryptax).

