### PR TITLE
Using specific install options for oletools, added requirements

### DIFF
--- a/remnux/python-packages/oletools.sls
+++ b/remnux/python-packages/oletools.sls
@@ -10,14 +10,20 @@ include:
   - remnux.packages.python3-pip
   - remnux.packages.python3-tk
   - remnux.packages.python-pip
+  - remnux.packages.libssl-dev
+  - remnux.packages.libffi-dev
 
 oletools:
   pip.installed:
     - bin_env: /usr/bin/python3
     - upgrade: True
+    - install_options:
+      - --prefix=/usr/local
     - require:
       - sls: remnux.packages.python3-pip
       - sls: remnux.packages.python3-tk
+      - sls: remnux.packages.libssl-dev
+      - sls: remnux.packages.libffi-dev
 
 remnux-python-packages-olevba-shebang:
   file.replace:


### PR DESCRIPTION
oletools was causing an issue (seen [here](https://github.com/REMnux/salt-states/issues/137)) whereby it would install to /usr/bin vice /usr/local/bin and generating an error with the file.replace function of the corresponding salt-state.

Added the install_options: function and used --prefix=/usr/local to bypass this issue. Also, during the build process in docker, the use of the install_options flag prevents the use of wheels:
`/usr/lib/python3/dist-packages/pip/commands/install.py:212: UserWarning: Disabling all use of wheels due to the use of --build-options / --global-options / --install-options.`
and identifies that cffi (which is required by cryptography, which is required by msoffcrypto-tool) is missing specific requirements (libssl-dev and libffi-dev). 

I identified those as specific requirements for this state to prevent the issue when building in docker. Installing in a plain Ubuntu VM with no Desktop Environment had no issues without the requirements though, so this is a preventative measure which has no additional impact on the toolset.

It is unclear at this point what is causing oletools to be installed in /usr/bin by default. Will continue to investigate out of curiosity, but I wanted to get this fix pushed first.