### PR TITLE
Fix for viper-framework bitstring duplicate - temporary

### DIFF
--- a/remnux/python-packages/viper-framework.sls
+++ b/remnux/python-packages/viper-framework.sls
@@ -124,6 +124,16 @@ remnux-python-packages-viper-modules-pymispgalaxies:
     - require:
       - git: remnux-python-packages-viper-modules-git
 
+remnux-python-packages-viper-modules-bitstring:
+  file.replace:
+    - name: {{ home }}/.viper/modules/requirements.txt
+    - pattern: 'bitstring==3.1.6'
+    - repl: ''
+    - count: 1
+    - prepend_if_not_found: False
+    - require:
+      - git: remnux-python-packages-viper-modules-git
+
 remnux-python-packages-viper-modules-init:
   cmd.run:
     - name: git submodule init


### PR DESCRIPTION
This fix is only meant to be temporary, until the issue is resolved at the source. 
Issue was raised [here](https://github.com/viper-framework/viper-modules/issues/9) over at the viper-framework/viper-modules repo. Once the issue is addressed and a solution provided on a more permanent basis, this fix will allow for a successful install of viper-framework.