### PR TITLE
Removal of viper-framework until python3.7 requirement addressed

### DIFF
--- a/remnux/python-packages/init.sls
+++ b/remnux/python-packages/init.sls
@@ -46,7 +46,7 @@ include:
   - remnux.python-packages.ratdecoders
   - remnux.python-packages.poster
   - remnux.python-packages.pylzma-python3
-  - remnux.python-packages.viper-framework
+#  - remnux.python-packages.viper-framework
   - remnux.python-packages.time-decode
   - remnux.python-packages.pcodedmp
   - remnux.python-packages.droidlysis
@@ -112,7 +112,7 @@ remnux-python-packages:
       - sls: remnux.python-packages.ratdecoders
       - sls: remnux.python-packages.poster
       - sls: remnux.python-packages.pylzma-python3
-      - sls: remnux.python-packages.viper-framework
+#      - sls: remnux.python-packages.viper-framework
       - sls: remnux.python-packages.time-decode
       - sls: remnux.python-packages.pcodedmp
       - sls: remnux.python-packages.droidlysis

--- a/remnux/python-packages/viper-framework.sls
+++ b/remnux/python-packages/viper-framework.sls
@@ -124,16 +124,6 @@ remnux-python-packages-viper-modules-pymispgalaxies:
     - require:
       - git: remnux-python-packages-viper-modules-git
 
-remnux-python-packages-viper-modules-bitstring:
-  file.replace:
-    - name: {{ home }}/.viper/modules/requirements.txt
-    - pattern: 'bitstring==3.1.6'
-    - repl: ''
-    - count: 1
-    - prepend_if_not_found: False
-    - require:
-      - git: remnux-python-packages-viper-modules-git
-
 remnux-python-packages-viper-modules-init:
   cmd.run:
     - name: git submodule init


### PR DESCRIPTION
This will address the recent viper-framework errors by not installing the tool. The requirement scrapysplashwrapper has recently updated it's python requirement to 3.7, but Ubuntu 18.04 comes with 3.6.9 by default. This recent upgrade breaks the install of viper-framework.

As such, we will remove viper-framework for the time being until the larger python3.7 issue is addressed.