### PR TITLE
Updated dexray hash and fixed minor issue

### DIFF
--- a/remnux/scripts/dexray.sls
+++ b/remnux/scripts/dexray.sls
@@ -18,7 +18,7 @@ remnux-scripts-dexray-source:
   file.managed:
     - name: /usr/local/bin/dexray
     - source: https://hexacorn.com/d/DeXRAY.pl 
-    - source_hash: sha256=9f314060960677a2c5feefe4e458a17a28694d4f38c05d3be8fe3db612829371
+    - source_hash: sha256=5a2759d89d8351a5728ce8eceb93db7bac80b062889f2d4ed33b2690303e4249
     - mode: 755
     - requires:
       - sls: remnux.packages.perl
@@ -28,3 +28,13 @@ remnux-scripts-dexray-source:
       - sls: remnux.perl-packages.digest-crc
       - sls: remnux.perl-packages.ole-storagelite
 
+remnux-scripts-dexray-replace:
+  file.replace:
+    - name: /usr/local/bin/dexray
+    - pattern: '@r0ns3n'
+    - repl: 'r0ns3n'
+    - backup: false
+    - prepend_if_not_found: false
+    - count: 3
+    - require:
+      - file: remnux-scripts-dexray-source


### PR DESCRIPTION
Updated the sha256 for DeXRAY to resolve [remnux-cli issue #11](https://github.com/REMnux/remnux-cli/issues/11).
Also, when the latest function was added, an error was introduced in the usage of the '@' symbol to identify the contributor. This caused a processing error, so I removed the '@' before the users name, to ensure the script functions as intended.