### PR TITLE
Add the Sleuthkit toolset

### DIFF
--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -167,6 +167,7 @@ include:
   - remnux.packages.android-project-creator
   - remnux.packages.libdpkg-perl
   - remnux.packages.sandfly-processdecloak
+  - remnux.packages.sleuthkit
 
 remnux-packages:
   test.nop:
@@ -337,3 +338,4 @@ remnux-packages:
       - sls: remnux.packages.android-project-creator
       - sls: remnux.packages.libdpkg-perl
       - sls: remnux.packages.sandfly-processdecloak
+      - sls: remnux.packages.sleuthkit

--- a/remnux/packages/sleuthkit.sls
+++ b/remnux/packages/sleuthkit.sls
@@ -1,0 +1,11 @@
+# Name: The Sleuth Kit
+# Website: https://www.sleuthkit.org/sleuthkit
+# Description: A collection of command line tools and a C library that allows you to analyze disk images and recover files from them.
+# Category: Examine Static Properties: General
+# Author: Brian Carrier, and others
+# License: the IBM Public License, the Common Public License, the GPL2: https://www.sleuthkit.org/sleuthkit/licenses.php
+# Notes: 
+
+remnux-packages-sleuthkit:
+  pkg.installed:
+    - name: sleuthkit


### PR DESCRIPTION
The Sleuthkit contains essential tools to analyze volumes and filesystem. I was a bit surprised it was missing from REMnux :-)