### PR TITLE
Change volatility branch pinning to master

### DIFF
--- a/remnux/python-packages/volatility.sls
+++ b/remnux/python-packages/volatility.sls
@@ -32,8 +32,9 @@ include:
 # openpyxl is needed for the timeliner plugin
 remnux-python-packages-volatility:
   pip.installed:
-    - name: git+https://github.com/volatilityfoundation/volatility.git@2.6.1
+    - name: git+https://github.com/volatilityfoundation/volatility.git@master
     - bin_env: /usr/bin/python
+    - upgrade: True
     - require:
       - sls: remnux.packages.git
       - sls: remnux.packages.python-pip


### PR DESCRIPTION
The 2.6.1 branch does not have all of the Windows 10 profiles, including 17763 and up.
Changing the branch to master, and adding `upgrade: True` will allow any future Windows 10 profiles (and any other profiles) to be included.