### PR TITLE
Updated r2pipe for Python3 install

### DIFF
--- a/remnux/python-packages/r2pipe.sls
+++ b/remnux/python-packages/r2pipe.sls
@@ -1,10 +1,9 @@
 include:
-  - remnux.packages.python-pip
   - remnux.packages.python3-pip
 
 r2pipe:
   pip.installed:
-    - bin_env: /usr/bin/python
+    - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
-      - sls: remnux.packages.python-pip
+      - sls: remnux.packages.python3-pip


### PR DESCRIPTION
This fixes r2pipe installation issues with their upgrade to python3-only compatibility.