### PR TITLE
Created Ubuntu 20 compat version of manalyze

### DIFF
--- a/remnux/packages/libboost-filesystem-dev.sls
+++ b/remnux/packages/libboost-filesystem-dev.sls
@@ -1,0 +1,2 @@
+libboost-filesystem-dev:
+  pkg.installed

--- a/remnux/packages/libboost-filesystem.sls
+++ b/remnux/packages/libboost-filesystem.sls
@@ -1,2 +1,0 @@
-libboost-filesystem1.65.1:
-  pkg.installed

--- a/remnux/packages/libboost-program-options-dev.sls
+++ b/remnux/packages/libboost-program-options-dev.sls
@@ -1,0 +1,2 @@
+libboost-program-options-dev:
+  pkg.installed

--- a/remnux/packages/libboost-program-options.sls
+++ b/remnux/packages/libboost-program-options.sls
@@ -1,2 +1,0 @@
-libboost-program-options1.65.1:
-  pkg.installed

--- a/remnux/packages/libboost-regex-dev.sls
+++ b/remnux/packages/libboost-regex-dev.sls
@@ -1,0 +1,2 @@
+libboost-regex-dev:
+  pkg.installed

--- a/remnux/packages/libboost-regex.sls
+++ b/remnux/packages/libboost-regex.sls
@@ -1,2 +1,0 @@
-libboost-regex1.65.1:
-  pkg.installed

--- a/remnux/packages/libboost-system.sls
+++ b/remnux/packages/libboost-system.sls
@@ -1,2 +1,0 @@
-libboost-system1.65.1:
-  pkg.installed

--- a/remnux/tools/manalyze.sls
+++ b/remnux/tools/manalyze.sls
@@ -7,22 +7,38 @@
 # Notes: Run "manalyze" to invoke the tool. To update the tool's Yara rules to include ClamAV, run "sudo /usr/local/manalyze/yara_rules/update_clamav_signatures.py". To query VirusTotal, add your API key to /usr/local/manalyze/manalyze.conf.
 
 include:
-  - remnux.packages.libboost-regex
-  - remnux.packages.libboost-system
-  - remnux.packages.libboost-filesystem
-  - remnux.packages.libboost-program-options
+  - remnux.packages.libboost-regex-dev
+  - remnux.packages.libboost-system-dev
+  - remnux.packages.libboost-filesystem-dev
+  - remnux.packages.libboost-program-options-dev
 
+{%- if grains['oscodename'] == "bionic" %}
 remnux-tools-manalyze-source:
   file.managed:
     - name: /usr/local/src/remnux/files/manalyze-0.9.tgz
-    - source: https://github.com/REMnux/distro/raw/master/files/manalyze-0.9.tgz
+    - source: https://github.com/REMnux/distro/raw/master/files/manalyze-0.9-bionic.tgz
     - source_hash: sha256=8a29949fbd4fd536f4822aec477861e730336a034af9f61376ecfce7dae7bfaa
     - makedirs: true
     - require:
-      - sls: remnux.packages.libboost-regex
-      - sls: remnux.packages.libboost-system
-      - sls: remnux.packages.libboost-filesystem
-      - sls: remnux.packages.libboost-program-options
+      - sls: remnux.packages.libboost-regex-dev
+      - sls: remnux.packages.libboost-system-dev
+      - sls: remnux.packages.libboost-filesystem-dev
+      - sls: remnux.packages.libboost-program-options-dev
+
+{%- elif grains['oscodename'] == "focal" %}
+remnux-tools-manalyze-source:
+  file.managed:
+    - name: /usr/local/src/remnux/files/manalyze-0.9.tgz
+    - source: https://github.com/REMnux/distro/raw/master/files/manalyze-0.9-focal.tgz
+    - source_hash: sha256=6fd34217764a4fad7590ed643963ab3c5a8ed3f60a2c3d449e6fca5fd86095f3
+    - makedirs: true
+    - require:
+      - sls: remnux.packages.libboost-regex-dev
+      - sls: remnux.packages.libboost-system-dev
+      - sls: remnux.packages.libboost-filesystem-dev
+      - sls: remnux.packages.libboost-program-options-dev
+
+{%- endif %}
 
 remnux-tools-manalyze-archive:
   archive.extracted:


### PR DESCRIPTION
This will pull the proper manalyze binary based on the codename (focal or bionic) for future compatibility. Each -dev changed defaults as well to the distros defaults, so no need to pin to a version.  