### PR TITLE
Updated dexray hash

### DIFF
--- a/remnux/scripts/dexray.sls
+++ b/remnux/scripts/dexray.sls
@@ -18,7 +18,7 @@ remnux-scripts-dexray-source:
   file.managed:
     - name: /usr/local/bin/dexray
     - source: https://hexacorn.com/d/DeXRAY.pl 
-    - source_hash: sha256=8ca90a25acd1a0da838c323db12f4706e7690351e995036a7f9b01300efe23c3
+    - source_hash: sha256=3ea9392ef860b2e26263c2dd160f3a6a33019fb6e377809feec3cad10a6439d8
     - mode: 755
     - requires:
       - sls: remnux.packages.perl
@@ -27,14 +27,3 @@ remnux-scripts-dexray-source:
       - sls: remnux.perl-packages.archive-zip
       - sls: remnux.perl-packages.digest-crc
       - sls: remnux.perl-packages.ole-storagelite
-
-remnux-scripts-dexray-replace:
-  file.replace:
-    - name: /usr/local/bin/dexray
-    - pattern: '@r0ns3n'
-    - repl: 'r0ns3n'
-    - backup: false
-    - prepend_if_not_found: false
-    - count: 3
-    - require:
-      - file: remnux-scripts-dexray-source


### PR DESCRIPTION
Dexray hash updated again (twice today actually).
Also removed the pattern replace, as the issue has since been mitigated by the author with the inclusion of escape's (\\).