### PR TITLE
Update fakenet for Focal compat

### DIFF
--- a/remnux/packages/fakenet-ng.sls
+++ b/remnux/packages/fakenet-ng.sls
@@ -10,13 +10,15 @@ include:
   - remnux.packages.python2-pip
   - remnux.packages.python3-pip
   - remnux.python-packages.cryptography
-  - remnux.repos.remnux
-
-fakenet-ng:
-  pkg.installed:
-    - pkgrepo: remnux
-    - require:
-      - sls: remnux.python-packages.cryptography
+  - remnux.packages.build-essential
+  - remnux.packages.libnetfilter-queue-dev
+  - remnux.packages.libnfnetlink-dev
+  - remnux.packages.git
+{% if grains['oscodename'] == "bionic" %}
+  - remnux.packages.python-dev
+{% elif grains['oscodename'] == "focal" %}
+  - remnux.packages.python2-dev
+{% endif %}
 
 pydivert:
   pip.installed:
@@ -53,3 +55,15 @@ pyopenssl:
     - bin_env: /usr/bin/python2
     - require:
       - sls: remnux.packages.python2-pip
+
+fakenet-ng:
+  pip.installed:
+    - name: git+https://github.com/fireeye/flare-fakenet-ng
+    - bin_env: /usr/bin/python2
+    - require:
+      - sls: remnux.packages.git
+      - sls: remnux.packages.python2-pip
+      - sls: remnux.python-packages.cryptography
+      - sls: remnux.packages.build-essential
+      - sls: remnux.packages.libnetfilter-queue-dev
+      - sls: remnux.packages.libnfnetlink-dev

--- a/remnux/packages/libnetfilter-queue-dev.sls
+++ b/remnux/packages/libnetfilter-queue-dev.sls
@@ -1,0 +1,2 @@
+libnetfilter-queue-dev:
+  pkg.installed

--- a/remnux/packages/libnfnetlink-dev.sls
+++ b/remnux/packages/libnfnetlink-dev.sls
@@ -1,0 +1,2 @@
+libnfnetlink-dev:
+  pkg.installed


### PR DESCRIPTION
In order to work around some compatibility issues with fakenet and python2 in Ubuntu Focal, the salt state had to be reorganized.
Two new packages are required (libnfnetlink-dev and libnetfilter-queue-dev), the repo build was removed (python issues), and a requirement for python-dev or python2-dev (oscodename dependent) was added.