### PR TITLE
Update pdftk for focal compat

### DIFF
--- a/remnux/packages/pdftk-java.sls
+++ b/remnux/packages/pdftk-java.sls
@@ -6,8 +6,15 @@
 # License: GNU General Public License (GPL) v2: https://gitlab.com/pdftk-java/pdftk/-/blob/master/LICENSE
 # Notes: pdftk
 
+{%- if grains['oscodename'] == "bionic" %}
 include:
   - remnux.repos.remnux
 
 pdftk-java:
   pkg.installed
+
+{%- elif grains['oscodename'] == "focal" %}
+pdftk-java:
+  pkg.installed
+
+{% endif %}


### PR DESCRIPTION
Since focal has a pdftk-java package already built, this state had to be updated to accommodate the bionic version from the remnux repo, and the focal version from launchpad.