### PR TITLE
Fix for pkg.uptodate issue with focal

### DIFF
--- a/remnux/packages/i386-architecture.sls
+++ b/remnux/packages/i386-architecture.sls
@@ -1,34 +1,28 @@
 i386-arch:
   cmd.run:
-    - name: dpkg --add-architecture i386
+    - name: dpkg --add-architecture i386 && apt-get update
     - unless: dpkg --print-foreign-architectures | grep i386
-
-apt-update:
-  pkg.uptodate:
-    - refresh: True
-    - require:
-      - cmd: i386-arch
 
 libc6:
   pkg.installed:
     - name: libc6
     - require:
-      - pkg: apt-update
+      - cmd: i386-arch
 
 libstdc++6:
   pkg.installed:
     - name: libstdc++6
     - require:
-      - pkg: apt-update
+      - cmd: i386-arch
 
 libncurses5:i386:
   pkg.installed:
-    - name: libncurses5:i386 
+    - name: libncurses5:i386
     - require:
-      - pkg: apt-update
-    
+      - cmd: i386-arch
+
 zlib1g:i386:
   pkg.installed:
     - name: zlib1g:i386
     - require:
-      - pkg: apt-update
+      - cmd: i386-arch


### PR DESCRIPTION
When processing the apt update request through pkg.uptodate, there is an issue with salt being able to parse the output, thus causing the i386 cmds to fail since they don't exist in the repo (since the apt update failed with the dpkg --add-architecture).

This state uses the cmd.run salt command to manually do the apt-get update to ensure the architecture is added and up to date prior to the installation of the i386 packages.