### PR TITLE
Updated packages for Focal

### DIFF
--- a/remnux/packages/enchant.sls
+++ b/remnux/packages/enchant.sls
@@ -1,2 +1,2 @@
-python-enchant:
+enchant:
   pkg.installed

--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -29,7 +29,7 @@ include:
   - remnux.packages.imagemagick
   - remnux.packages.inetsim
   - remnux.packages.inspircd
-  - remnux.packages.ipython
+  - remnux.packages.ipython3
   - remnux.packages.lame
   - remnux.packages.libboost-dev
   - remnux.packages.libboost-python-dev
@@ -61,7 +61,7 @@ include:
   - remnux.packages.python-crypto
 #  - remnux.packages.python-dev
   - remnux.packages.python-dnspython
-  - remnux.packages.python-enchant
+  - remnux.packages.enchant
   - remnux.packages.python-future
   - remnux.packages.python-gtksourceview2
   - remnux.packages.python-hachoir-core
@@ -198,7 +198,7 @@ remnux-packages:
       - sls: remnux.packages.imagemagick
       - sls: remnux.packages.inetsim
       - sls: remnux.packages.inspircd
-      - sls: remnux.packages.ipython
+      - sls: remnux.packages.ipython3
       - sls: remnux.packages.lame
       - sls: remnux.packages.libboost-dev
       - sls: remnux.packages.libboost-python-dev
@@ -229,7 +229,7 @@ remnux-packages:
       - sls: remnux.packages.python-crypto
 #      - sls: remnux.packages.python-dev
       - sls: remnux.packages.python-dnspython
-      - sls: remnux.packages.python-enchant
+      - sls: remnux.packages.enchant
       - sls: remnux.packages.python-future
       - sls: remnux.packages.python-gtksourceview2
       - sls: remnux.packages.python-hachoir-core

--- a/remnux/packages/inspircd.sls
+++ b/remnux/packages/inspircd.sls
@@ -6,18 +6,37 @@
 # License: GNU General Public License (GPL) v2: https://docs.inspircd.org/license/
 # Notes: 
 
-remnux-inspircd-source:
-  file.managed:
-    - name: /usr/local/src/inspircd_3.6.0-1_amd64.deb
-    - source: https://github.com/inspircd/inspircd/releases/download/v3.6.0/inspircd_3.6.0-1_amd64.deb
-    - source_hash: sha256=672b0f7630debc20f57d4bd06790d73636b152baf06b9602754c85a571ea469c
+{%- if grains['oscodename'] == "bionic" %}
 
-remnux-inspircd:
+remnux-packages-inspircd-source:
+  file.managed:
+    - name: /usr/local/src/inspircd_3.8.1.ubuntu18.04.1_amd64.deb
+    - source: https://github.com/inspircd/inspircd/releases/download/v3.8.1/inspircd_3.8.1.ubuntu18.04.1_amd64.deb
+    - source_hash: sha256=d993a9333395826d1312c940ef72e53c5d67217f481c08c2b00709352bdcae8f
+
+remnux-packages-inspircd-install:
   pkg.installed:
     - sources:
-      - inspircd: /usr/local/src/inspircd_3.6.0-1_amd64.deb
+      - inspircd: /usr/local/src/inspircd_3.8.1.ubuntu18.04.1_amd64.deb
     - watch:
-      - file: remnux-inspircd-source
+      - file: remnux-packages-inspircd-source
+
+{%- elif grains['oscodename'] == "focal" %}
+
+remnux-packages-inspircd-source:
+  file.managed:
+    - name: /usr/local/src/inspircd_3.8.1.ubuntu20.04.1_amd64.deb
+    - source: https://github.com/inspircd/inspircd/releases/download/v3.8.1/inspircd_3.8.1.ubuntu20.04.1_amd64.deb
+    - source_hash: sha256=62cdd3dc915135ef4331b384217475ed0a4421198a02398efe1e016877c8c8dd
+
+remnux-packages-inspircd-install:
+  pkg.installed:
+    - sources:
+      - inspircd: /usr/local/src/inspircd_3.8.1.ubuntu20.04.1_amd64.deb
+    - watch:
+      - file: remnux-packages-inspircd-source
+
+{% endif %}
 
 # Runlevel isn't in a Docker container, so check whether it exists before
 # trying to control services
@@ -28,6 +47,6 @@ inspircd-service:
     - name: inspircd
     - enable: False
     - watch:
-      - pkg: remnux-inspircd
+      - pkg: remnux-packages-inspircd-install
 
 {% endif %}

--- a/remnux/packages/ipython.sls
+++ b/remnux/packages/ipython.sls
@@ -1,3 +1,0 @@
-remnux-ipython:
-  pkg.installed:
-    - name: ipython

--- a/remnux/packages/ipython3.sls
+++ b/remnux/packages/ipython3.sls
@@ -1,0 +1,3 @@
+remnux-packages-ipython3:
+  pkg.installed:
+    - name: ipython3

--- a/remnux/python-packages/pyenchant.sls
+++ b/remnux/python-packages/pyenchant.sls
@@ -1,0 +1,13 @@
+include:
+  - remnux.packages.python3-pip
+  - remnux.packages.python2-pip
+  - remnux.packages.enchant
+
+remnux-python-packages-pyenchant:
+  pip.installed:
+    - name: pyenchant
+    - bin_env: /usr/bin/python2
+    - upgrade: True
+    - require:
+      - sls: remnux.packages.enchant
+      - sls: remnux.packages.python2-pip

--- a/remnux/scripts/brxor.sls
+++ b/remnux/scripts/brxor.sls
@@ -7,7 +7,8 @@
 # Notes: 
 
 include:
-  - remnux.packages.python-enchant
+  - remnux.packages.enchant
+  - remnux.python-packages.pyenchant
 
 remnux-scripts-brxor-source:
   file.managed:
@@ -17,4 +18,16 @@ remnux-scripts-brxor-source:
     - makedirs: false
     - mode: 755
     - require:
-      - sls: remnux.packages.python-enchant
+      - sls: remnux.packages.enchant
+      - sls: remnux.python-packages.pyenchant
+
+remnux-scripts-brxor-shebang:
+  file.replace:
+    - name: /usr/local/bin/brxor.py
+    - pattern: '#!/usr/bin/python'
+    - repl: '#!/usr/bin/env python2'
+    - count: 1
+    - prepend_if_not_found: False
+    - watch:
+      - file: remnux-scripts-brxor-source
+


### PR DESCRIPTION
Modifications will allow for greater compatibility with focal, while retaining compatibility with bionic. 
Several python-* packages are no longer available for focal, so this state replaces python-enchant with enchant.
Modified the header of brxor.py to call python2 vice python.
iPython is no longer available for Focal, so modified it to upgrade to iPython3 instead (available in both, and since Python2 is already EOL).