### PR TITLE
Adding new Outlook msg parser

### DIFF
--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -159,6 +159,7 @@ include:
   - remnux.packages.ilspy
   - remnux.packages.ghidra
   - remnux.packages.bddisasm
+  - remnux.packages.tzdata
 
 remnux-packages:
   test.nop:
@@ -321,3 +322,4 @@ remnux-packages:
       - sls: remnux.packages.ilspy
       - sls: remnux.packages.ghidra
       - sls: remnux.packages.bddisasm
+      - sls: remnux.packages.tzdata

--- a/remnux/packages/tzdata.sls
+++ b/remnux/packages/tzdata.sls
@@ -1,0 +1,2 @@
+tzdata:
+  pkg.latest

--- a/remnux/python3-packages/init.sls
+++ b/remnux/python3-packages/init.sls
@@ -39,6 +39,7 @@ include:
   - remnux.python3-packages.wheel
   - remnux.python3-packages.setuptools
   - remnux.python3-packages.hachoir
+  - remnux.python3-packages.msg-extractor
 
 remnux-python3-packages:
   test.nop:
@@ -83,3 +84,4 @@ remnux-python3-packages:
       - sls: remnux.python3-packages.wheel
       - sls: remnux.python3-packages.setuptools
       - sls: remnux.python3-packages.hachoir
+      - sls: remnux.python3-packages.msg-extractor

--- a/remnux/python3-packages/msg-extractor.sls
+++ b/remnux/python3-packages/msg-extractor.sls
@@ -1,0 +1,22 @@
+# Name: msg-extractor
+# Website: https://github.com/TeamMsgExtractor/msg-extractor
+# Description: Extract emails and attachments from Outlooks .msg files
+# Category: Analyze Documents: Email messages
+# Author: https://github.com/TeamMsgExtractor/msg-extractor#credits
+# License: GNU General Public LIcense v3.0: https://github.com/TeamMsgExtractor/msg-extractor/blob/master/LICENSE.txt
+# Notes: extract_msg
+
+include:
+  - remnux.packages.python3-pip
+  - remnux.packages.git
+  - remnux.packages.tzdata
+
+remnux-python3-packages-extract-msg:
+  pip.installed:
+    - name: git+https://github.com/TeamMsgExtractor/msg-extractor
+    - bin_env: /usr/bin/python3
+    - upgrade: True
+    - require:
+      - sls: remnux.packages.python3-pip
+      - sls: remnux.packages.git
+      - sls: remnux.packages.tzdata


### PR DESCRIPTION
Found a promising tool, msg-extractor, used for extracting contents and attachments from msg files. Has functionality which works well with msgconvert (from libemail-outlook-message-perl). 
I find this one does a good job of parsing the embedded attachment from the e-mail, and think it could be useful. Has already proven useful in one instance for me this week.

