### PR TITLE
Fixes to avoid pip NoneType error

### DIFF
--- a/remnux/python3-packages/chepy.sls
+++ b/remnux/python3-packages/chepy.sls
@@ -23,6 +23,5 @@ remnux-python3-packages-chepy-extras:
   pip.installed:
     - name: chepy[extras]
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - watch:
       - pip: remnux-python3-packages-chepy

--- a/remnux/python3-packages/malwoverview.sls
+++ b/remnux/python3-packages/malwoverview.sls
@@ -46,7 +46,6 @@ remnux-python3-packages-malwoverview-install:
   pip.installed:
     - name: malwoverview
     - bin_env: /opt/malwoverview/bin/python3
-    - upgrade: True
     - require:
       - sls: remnux.packages.python3-pip
       - virtualenv: remnux-python3-packages-malwoverview-virtualenv

--- a/remnux/python3-packages/msoffcrypto-tool.sls
+++ b/remnux/python3-packages/msoffcrypto-tool.sls
@@ -13,6 +13,5 @@ remnux-python3-packages-msoffcrypto-tool-install:
   pip.installed:
     - name: msoffcrypto-tool
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
       - sls: remnux.packages.python3-pip

--- a/remnux/python3-packages/olefile.sls
+++ b/remnux/python3-packages/olefile.sls
@@ -5,6 +5,5 @@ remnux-python3-packages-olefile3:
   pip.installed:
     - name: olefile
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
       - sls: remnux.packages.python3-pip

--- a/remnux/python3-packages/oletools.sls
+++ b/remnux/python3-packages/oletools.sls
@@ -15,7 +15,6 @@ include:
 oletools:
   pip.installed:
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - install_options:
       - --prefix=/usr/local
     - require:

--- a/remnux/python3-packages/pcodedmp.sls
+++ b/remnux/python3-packages/pcodedmp.sls
@@ -12,7 +12,6 @@ include:
 pcodedmp:
   pip.installed:
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
       - sls: remnux.packages.python3-pip
 

--- a/remnux/python3-packages/peframe.sls
+++ b/remnux/python3-packages/peframe.sls
@@ -12,19 +12,16 @@ include:
   - remnux.packages.swig
   - remnux.packages.python3-pip
 
-{%- if grains['oscodename'] == "bionic" %}
-remnux-python3-packages-peframe:
-  pip.installed:
-    - name: git+https://github.com/guelfoweb/peframe.git@master
-    - upgrade: True
-    - bin_env: /usr/bin/python3
-    - require:
-      - sls: remnux.packages.git
-      - sls: remnux.packages.libssl-dev
-      - sls: remnux.packages.swig
-      - sls: remnux.packages.python3-pip
+#remnux-python3-packages-peframe:
+#  pip.installed:
+#    - name: git+https://github.com/guelfoweb/peframe.git@master
+#    - bin_env: /usr/bin/python3
+#    - require:
+#      - sls: remnux.packages.git
+#      - sls: remnux.packages.libssl-dev
+#      - sls: remnux.packages.swig
+#      - sls: remnux.packages.python3-pip
 
-{%- elif grains['oscodename'] == "focal" %}
 remnux-python3-packages-peframe:
   git.cloned:
     - name: https://github.com/guelfoweb/peframe.git
@@ -51,4 +48,3 @@ remnux-python3-packages-peframe-install:
       - sls: remnux.packages.libssl-dev
       - sls: remnux.packages.swig
 
-{%- endif %}

--- a/remnux/python3-packages/protobuf.sls
+++ b/remnux/python3-packages/protobuf.sls
@@ -5,6 +5,5 @@ remnux-python3-packages-protobuf-install:
   pip.installed:
     - name: protobuf
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
       - sls: remnux.packages.python3-pip

--- a/remnux/python3-packages/setuptools.sls
+++ b/remnux/python3-packages/setuptools.sls
@@ -5,6 +5,5 @@ remnux-python3-packages-setuptools:
   pip.installed:
     - name: setuptools
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
       - sls: remnux.packages.python3-pip

--- a/remnux/python3-packages/wheel.sls
+++ b/remnux/python3-packages/wheel.sls
@@ -5,6 +5,5 @@ remnux-python3-packages-wheel:
   pip.installed:
     - name: wheel
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
       - sls: remnux.packages.python3-pip


### PR DESCRIPTION
The fixes applied here remove the 'upgrade: True' for several pip.installed states. There are two current issues at play: One which comes with pip3 20.3+ and the currently-disabled pip search feature, and one which is a result of a pip3 versioning issue in pip3 20.3 and SaltStack (referenced here - https://github.com/saltstack/salt/issues/59100).
The error in the saltstack log is:
```
line 2087, in wrapper\n    return f(*args, **kwargs)\n  File \"/usr/lib/python3/dist-packages/salt/states/pip_state.py\",
      line 866, in installed\n    **kwargs\n  File \"/usr/lib/python3/dist-packages/salt/states/pip_state.py\",
      line 329, in _check_if_installed\n    desired_version = available_versions[-1]\nTypeError:
      'NoneType' object is not subscriptable\n"
```
Until the issue is resolved on a larger scale, these states have had their upgrade: True removed so as not to cause the error, and prevent the installation of several python3 packages. These fixes will allow all states to be installed, regardless of pip version or Ubuntu version (18/20).
