### PR TITLE
Using manual pip upgrades for select states

### DIFF
--- a/remnux/python3-packages/chepy.sls
+++ b/remnux/python3-packages/chepy.sls
@@ -14,7 +14,7 @@ remnux-python3-packages-chepy:
   pip.installed:
     - name: chepy
     - bin_env: /usr/bin/python3
-    - upgrade: True
+#    - upgrade: True
     - require:
       - sls: remnux.packages.python3-pip    
       - sls: remnux.python3-packages.pycryptodome

--- a/remnux/python3-packages/init.sls
+++ b/remnux/python3-packages/init.sls
@@ -40,6 +40,7 @@ include:
   - remnux.python3-packages.setuptools
   - remnux.python3-packages.hachoir
   - remnux.python3-packages.msg-extractor
+  - remnux.python3-packages.upgrade
 
 remnux-python3-packages:
   test.nop:
@@ -85,3 +86,4 @@ remnux-python3-packages:
       - sls: remnux.python3-packages.setuptools
       - sls: remnux.python3-packages.hachoir
       - sls: remnux.python3-packages.msg-extractor
+      - sls: remnux.python3-packages.upgrade

--- a/remnux/python3-packages/oletools.sls
+++ b/remnux/python3-packages/oletools.sls
@@ -15,8 +15,6 @@ include:
 oletools:
   pip.installed:
     - bin_env: /usr/bin/python3
-    - install_options:
-      - --prefix=/usr/local
     - require:
       - sls: remnux.packages.python3-pip
       - sls: remnux.packages.python3-tk

--- a/remnux/python3-packages/upgrade.sls
+++ b/remnux/python3-packages/upgrade.sls
@@ -1,0 +1,24 @@
+include:
+  - remnux.packages.python3-pip
+  - remnux.python3-packages.chepy
+  - remnux.python3-packages.malwoverview
+  - remnux.python3-packages.msoffcrypto-tool
+  - remnux.python3-packages.olefile
+  - remnux.python3-packages.oletools
+  - remnux.python3-packages.pcodedmp
+  - remnux.python3-packages.peframe
+  - remnux.python3-packages.protobuf
+  - remnux.python3-packages.setuptools
+  - remnux.python3-packages.wheel
+
+remnux-python3-packages-pypi-upgrade:
+  cmd.run:
+    - name: /usr/bin/python3 -m pip install --upgrade chepy chepy[extras] msoffcrypto-tool olefile oletools pcodedmp protobuf setuptools wheel
+
+remnux-python3-packages-git-upgrade:
+  cmd.run:
+    - name: /usr/bin/python3 -m pip install --upgrade git+https://github.com/guelfoweb/peframe.git@master
+
+remnux-python3-packages-malwoverview-upgrade:
+  cmd.run:
+    - name: /opt/malwoverview/bin/python3 -m pip install --upgrade malwoverview

--- a/remnux/python3-packages/upgrade.sls
+++ b/remnux/python3-packages/upgrade.sls
@@ -14,11 +14,27 @@ include:
 remnux-python3-packages-pypi-upgrade:
   cmd.run:
     - name: /usr/bin/python3 -m pip install --upgrade chepy chepy[extras] msoffcrypto-tool olefile oletools pcodedmp protobuf setuptools wheel
+    - require:
+      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.chepy
+      - sls: remnux.python3-packages.msoffcrypto-tool
+      - sls: remnux.python3-packages.olefile
+      - sls: remnux.python3-packages.oletools
+      - sls: remnux.python3-packages.pcodedmp
+      - sls: remnux.python3-packages.protobuf
+      - sls: remnux.python3-packages.setuptools
+      - sls: remnux.python3-packages.wheel
 
 remnux-python3-packages-git-upgrade:
   cmd.run:
     - name: /usr/bin/python3 -m pip install --upgrade git+https://github.com/guelfoweb/peframe.git@master
+    - require:
+      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.peframe
 
 remnux-python3-packages-malwoverview-upgrade:
   cmd.run:
     - name: /opt/malwoverview/bin/python3 -m pip install --upgrade malwoverview
+    - require:
+      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.malwoverview


### PR DESCRIPTION
Added a single 'upgrade' state for pip3 upgrades to account for the states that were causing an error when pip 20.3 was installed. Once the salt/pip3 20.3 errors are resolved, the original states can revert to an 'upgrade: True' configuration. In the meantime, instead of editing each state to manually configure the pip cmd, I added the upgrade state which will manually upgrade (cmd.run) each of the pip packages.

Additionally, during testing, pip 20.3 and saltstack do not accept the 'install_options --prefix' option any longer, and this causes the oletools state to fail. Removing the install_options allows the install to complete, but additionally the install_options command is no longer required, as the oletools package installs correctly from pip.