### PR TITLE
Update pev to force install/upgrade from remnux repo

### DIFF
--- a/remnux/packages/pev.sls
+++ b/remnux/packages/pev.sls
@@ -12,4 +12,6 @@ include:
 remnux-packages-pev:
   pkg.installed:
     - name: pev
+    - version: latest
+    - upgrade: True
     - pkgrepo: remnux


### PR DESCRIPTION
Tested this a few different ways and this method seems to work, adding `version: latest`, `upgrade: True` and defining `pkgrepo: remnux`.
Method for testing:
1. From bionic docker, `apt update && apt install wget gnupg pev`
2. `readpe -V` to get version `0.80` from the Ubuntu repo
3. `salt-call -l debug --local --retcode-passthrough --state-output=mixed state.sls remnux.packages.pev pillar='{"remnux_user": "remnux"}'` - which included the changes from this PR
4. Confirm version upgrade: `[DEBUG   ] Current version (['0.80-4build1']) did not match desired version specification (0.81-1-bionic), adding to installation targets`
```
[INFO    ] Made the following changes:
'pev' changed from '0.80-4build1' to '0.81-1-bionic'
```