### PR TITLE
Add binwalk

### DIFF
--- a/remnux/packages/binwalk.sls
+++ b/remnux/packages/binwalk.sls
@@ -1,0 +1,10 @@
+# Name: binwalk
+# Website: https://github.com/ReFirmLabs/binwalk
+# Description: Firmware analysis and reverse engineering tool
+# Category: Examine Static Properties: General, Statically Analyze Code: Unpacking
+# Author: Craig Heffner, ReFirmLabs
+# License: MIT License: https://github.com/ReFirmLabs/binwalk/blob/master/LICENSE
+# Notes: binwalk
+
+binwalk:
+  pkg.installed

--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -153,6 +153,7 @@ include:
   - remnux.packages.ghidra
   - remnux.packages.bddisasm
   - remnux.packages.tzdata
+  - remnux.packages.binwalk
 
 remnux-packages:
   test.nop:
@@ -309,3 +310,4 @@ remnux-packages:
       - sls: remnux.packages.ghidra
       - sls: remnux.packages.bddisasm
       - sls: remnux.packages.tzdata
+      - sls: remnux.packages.binwalk


### PR DESCRIPTION
binwalk is a great tool for analyzing and extracting firmware from many types of devices. I've especially found it helpful over the years when working on Cisco IOS and firmware from various other routers.

Version 2.1.1 is available in apt on Ubuntu 18.04, and 2.2.0 in apt on Ubuntu Focal. This method of installation is much cleaner than utilizing the python method from the repo.