### PR TITLE
Python3 pip issues and setuptools_rust

### DIFF
--- a/remnux/python3-packages/androguard.sls
+++ b/remnux/python3-packages/androguard.sls
@@ -7,16 +7,15 @@
 # Notes: androarsc.py, androauto.py, androaxml.py, androcg.py, androdd.py, androdis.py, androguard, androgui.py, androlyze.py, androsign.py
 
 include:
-  - remnux.packages.python3-pip
   - remnux.packages.python3-pyqt5
+  - remnux.python3-packages.pip
   - remnux.python3-packages.pyperclip
 
 remnux-python3-packages-androguard:
   pip.installed:
     - name: androguard
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
       - sls: remnux.packages.python3-pyqt5
+      - sls: remnux.python3-packages.pip
       - sls: remnux.python3-packages.pyperclip

--- a/remnux/python3-packages/cffi.sls
+++ b/remnux/python3-packages/cffi.sls
@@ -1,9 +1,9 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
-cffi:
+remnux-python3-packages-cffi:
   pip.installed:
+    - name: cffi
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/chepy.sls
+++ b/remnux/python3-packages/chepy.sls
@@ -7,16 +7,15 @@
 # Notes: chepy
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.python3-packages.pycryptodome
 
 remnux-python3-packages-chepy:
   pip.installed:
-    - name: chepy
+    - name: chepy==2.6.3
     - bin_env: /usr/bin/python3
-#    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip    
+      - sls: remnux.python3-packages.pip    
       - sls: remnux.python3-packages.pycryptodome
 
 remnux-python3-packages-chepy-extras:

--- a/remnux/python3-packages/chepy.sls
+++ b/remnux/python3-packages/chepy.sls
@@ -12,7 +12,7 @@ include:
 
 remnux-python3-packages-chepy:
   pip.installed:
-    - name: chepy==2.6.3
+    - name: chepy
     - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.python3-packages.pip    

--- a/remnux/python3-packages/colorama.sls
+++ b/remnux/python3-packages/colorama.sls
@@ -1,9 +1,9 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
-colorama:
+remnux-python3-packages-colorama:
   pip.installed:
+    - name: colorama
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/dc3-mwcp.sls
+++ b/remnux/python3-packages/dc3-mwcp.sls
@@ -7,12 +7,11 @@
 # Notes: mwcp
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-dc3-mwcp-install:
   pip.installed:
     - name: mwcp
-    - upgrade: True
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/docker-compose.sls
+++ b/remnux/python3-packages/docker-compose.sls
@@ -1,9 +1,10 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
+  - remnux.python3-packages.setuptools-rust
 
 docker-compose:
   pip.installed:
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
+      - sls: remnux.python3-packages.setuptools-rust

--- a/remnux/python3-packages/droidlysis.sls
+++ b/remnux/python3-packages/droidlysis.sls
@@ -12,7 +12,7 @@
 {% endif %}
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.tools.apktool
   - remnux.packages.baksmali
   - remnux.packages.dex2jar
@@ -22,14 +22,12 @@ include:
 remnux-python-packages-droidlysis:
   pip.installed:
     - name: droidlysis
-    - upgrade: True
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
       - sls: remnux.tools.apktool
       - sls: remnux.packages.baksmali
       - sls: remnux.packages.dex2jar
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.procyon-decompiler
       - sls: remnux.packages.unzip
 

--- a/remnux/python3-packages/fakemail.sls
+++ b/remnux/python3-packages/fakemail.sls
@@ -9,15 +9,14 @@
 {%- if grains['oscodename'] == "focal" %}
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-fakemail:
   pip.installed:
     - name: fakemail
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
 
 {%- elif grains['oscodename'] == "bionic" %}
 

--- a/remnux/python3-packages/frida.sls
+++ b/remnux/python3-packages/frida.sls
@@ -7,12 +7,11 @@
 # Notes: frida, frida-ps, frida-trace, frida-discover, frida-ls-devices, frida-kill
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
-remnux-python-packages-frida-install:
+remnux-python3-packages-frida-install:
   pip.installed:
     - name: frida-tools
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/hachoir.sls
+++ b/remnux/python3-packages/hachoir.sls
@@ -7,16 +7,15 @@
 # Notes: hachoir-metadata, hachoir-grep, hachoir-strip, hachoir-urwid, hachoir-wx
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.packages.python3-urwid
 
 remnux-python3-packages-hachoir:
   pip.installed:
     - name: hachoir
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.python3-urwid
 
 remnux-python3-packages-hachoir-wx:

--- a/remnux/python3-packages/ioc-parser.sls
+++ b/remnux/python3-packages/ioc-parser.sls
@@ -7,14 +7,13 @@
 # Notes:
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.packages.git
 
 remnux-python3-packages-ioc-parser:
   pip.installed:
     - name: git+https://github.com/buffer/ioc_parser
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.git

--- a/remnux/python3-packages/ipwhois.sls
+++ b/remnux/python3-packages/ipwhois.sls
@@ -7,30 +7,30 @@
 # Notes: ipwhois_cli.py, ipwhois_utils_cli.py
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
-ipwhois:
+remnux-python3-packages-ipwhois:
   pip.installed:
+    - name: ipwhois
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
 
-remnux-python-packages-ipwhois_cli-shebang:
+remnux-python3-packages-ipwhois_cli-shebang:
   file.prepend:
     - name: /usr/local/bin/ipwhois_cli.py
     - text: '#!/usr/bin/env python3'
     - require:
-      - pip: ipwhois
+      - pip: remnux-python3-packages-ipwhois
 
-remnux-python-packages-ipwhois_utils-shebang:
+remnux-python3-packages-ipwhois_utils-shebang:
   file.prepend:
     - name: /usr/local/bin/ipwhois_utils_cli.py
     - text: '#!/usr/bin/env python3'
     - require:
-      - pip: ipwhois
+      - pip: remnux-python3-packages-ipwhois
     - watch:
-      - file: remnux-python-packages-ipwhois_cli-shebang
+      - file: remnux-python3-packages-ipwhois_cli-shebang
 
 /usr/local/bin/ipwhois_cli.py:
   file.managed:

--- a/remnux/python3-packages/jsbeautifier.sls
+++ b/remnux/python3-packages/jsbeautifier.sls
@@ -7,12 +7,11 @@
 # Notes: js-beautify
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-jsbeautifier:
   pip.installed:
     - name: jsbeautifier
-    - upgrade: True
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/malchive.sls
+++ b/remnux/python3-packages/malchive.sls
@@ -7,16 +7,15 @@
 # Notes: Malchive command-line tools start with the prefix `malutil-`. See [utilities documentation](https://github.com/MITRECND/malchive/wiki/Utilities) for details.
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.packages.git
   - remnux.python3-packages.cffi
 
 remnux-python3-packages-malchive:
   pip.installed:
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - name: git+https://github.com/MITRECND/malchive.git@main
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.git
       - sls: remnux.python3-packages.cffi

--- a/remnux/python3-packages/malwoverview.sls
+++ b/remnux/python3-packages/malwoverview.sls
@@ -19,7 +19,7 @@
 {% endif %}
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.packages.git
   - remnux.config.user
   - remnux.packages.python3-virtualenv
@@ -37,7 +37,7 @@ remnux-python3-packages-malwoverview-virtualenv:
       - setuptools
       - wheel
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.python3-virtualenv
       - sls: remnux.packages.python3-venv
       - sls: remnux.packages.virtualenv
@@ -47,7 +47,7 @@ remnux-python3-packages-malwoverview-install:
     - name: malwoverview
     - bin_env: /opt/malwoverview/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - virtualenv: remnux-python3-packages-malwoverview-virtualenv
       - sls: remnux.packages.git
       - sls: remnux.config.user

--- a/remnux/python3-packages/msg-extractor.sls
+++ b/remnux/python3-packages/msg-extractor.sls
@@ -3,11 +3,11 @@
 # Description: Extract emails and attachments from MSG files.
 # Category: Analyze Documents: Email messages
 # Author: https://github.com/TeamMsgExtractor/msg-extractor#credits
-# License: GNU General Public LIcense v3.0: https://github.com/TeamMsgExtractor/msg-extractor/blob/master/LICENSE.txt
+# License: GNU General Public License v3.0: https://github.com/TeamMsgExtractor/msg-extractor/blob/master/LICENSE.txt
 # Notes: extract_msg
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.packages.git
   - remnux.packages.tzdata
 
@@ -15,8 +15,7 @@ remnux-python3-packages-extract-msg:
   pip.installed:
     - name: git+https://github.com/TeamMsgExtractor/msg-extractor
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.git
       - sls: remnux.packages.tzdata

--- a/remnux/python3-packages/msoffcrypto-tool.sls
+++ b/remnux/python3-packages/msoffcrypto-tool.sls
@@ -7,11 +7,13 @@
 # Notes: 
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
+  - remnux.python3-packages.setuptools-rust
 
 remnux-python3-packages-msoffcrypto-tool-install:
   pip.installed:
     - name: msoffcrypto-tool
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
+      - sls: remnux.python3-packages.setuptools-rust

--- a/remnux/python3-packages/name-that-hash.sls
+++ b/remnux/python3-packages/name-that-hash.sls
@@ -9,19 +9,18 @@
 {%- if grains['oscodename'] == "focal" %}
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
-remnux-python3-name-that-hash-install:
+remnux-python3-packages-name-that-hash-install:
   pip.installed:
     - name: name-that-hash
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
 
 {%- elif grains['oscodename'] == "bionic" %}
 
-remnux-python3-name-that-hash-install:
+remnux-python3-packages-name-that-hash-install:
   test.nop
 
 {%- endif %}

--- a/remnux/python3-packages/olefile.sls
+++ b/remnux/python3-packages/olefile.sls
@@ -1,9 +1,9 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-olefile3:
   pip.installed:
     - name: olefile
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/oletools.sls
+++ b/remnux/python3-packages/oletools.sls
@@ -7,7 +7,7 @@
 # Notes: mraptor, msodde, olebrowse, oledir, oleid, olemap, olemeta, oleobj, oletimes, olevba, pyxswf, rtfobj, ezhexviewer
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.packages.python3-tk
   - remnux.packages.libssl-dev
   - remnux.packages.libffi-dev
@@ -16,7 +16,7 @@ oletools:
   pip.installed:
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.python3-tk
       - sls: remnux.packages.libssl-dev
       - sls: remnux.packages.libffi-dev

--- a/remnux/python3-packages/pcodedmp.sls
+++ b/remnux/python3-packages/pcodedmp.sls
@@ -7,13 +7,13 @@
 # Notes:
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 pcodedmp:
   pip.installed:
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
 
 remnux-python3-packages-pcodedmp-shebang:
   file.replace:

--- a/remnux/python3-packages/pe-tree.sls
+++ b/remnux/python3-packages/pe-tree.sls
@@ -7,15 +7,14 @@
 # Notes: pe-tree
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-pe-tree:
   pip.installed:
     - name: pe_tree
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - extra_args:
       - --only-binary
       - pyqt5
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/pefile.sls
+++ b/remnux/python3-packages/pefile.sls
@@ -7,11 +7,11 @@
 # Notes: https://github.com/erocarrera/pefile/blob/wiki/UsageExamples.md#introduction
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-pefile3:
   pip.installed:
     - name: pefile
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/peframe.sls
+++ b/remnux/python3-packages/peframe.sls
@@ -9,14 +9,14 @@
 include:
   - remnux.packages.libssl-dev
   - remnux.packages.swig
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-peframe-remove:
   pip.removed:
     - name: peframe
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
 
 remnux-python3-packages-peframe:
   pip.installed:
@@ -25,4 +25,4 @@ remnux-python3-packages-peframe:
     - require:
       - sls: remnux.packages.libssl-dev
       - sls: remnux.packages.swig
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/pip.sls
+++ b/remnux/python3-packages/pip.sls
@@ -3,8 +3,7 @@ include:
 
 remnux-python3-packages-pip3:
   pip.installed:
-    - name: pip
-    - upgrade: True
+    - name: pip==21.0.1
     - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.packages.python3-pip

--- a/remnux/python3-packages/protobuf.sls
+++ b/remnux/python3-packages/protobuf.sls
@@ -1,9 +1,9 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-protobuf-install:
   pip.installed:
     - name: protobuf
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/pycryptodomex.sls
+++ b/remnux/python3-packages/pycryptodomex.sls
@@ -1,9 +1,9 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 pycryptodomex:
   pip.installed:
     - bin_env: /usr/bin/python3
     - name: pycryptodomex == 3.7.3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/pyelftools.sls
+++ b/remnux/python3-packages/pyelftools.sls
@@ -7,12 +7,11 @@
 # Notes: readelf.py
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-pyelftools:
   pip.installed:
     - name: pyelftools
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/pygraphviz.sls
+++ b/remnux/python3-packages/pygraphviz.sls
@@ -1,17 +1,13 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.packages.libgraphviz-dev
   - remnux.packages.graphviz
 
 remnux-python3-packages-pygraphviz:
   pip.installed:
-    - name: pygraphviz == 1.6
+    - name: pygraphviz
     - bin_env: /usr/bin/python3
-    - upgrade: True
-    - install_options:
-      - --include-path=/usr/include/graphviz
-      - --library-path=/usr/lib/graphviz
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.graphviz
       - sls: remnux.packages.libgraphviz-dev

--- a/remnux/python3-packages/pylzma.sls
+++ b/remnux/python3-packages/pylzma.sls
@@ -1,10 +1,9 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-pylzma:
   pip.installed:
     - name: pylzma
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/pyperclip.sls
+++ b/remnux/python3-packages/pyperclip.sls
@@ -1,10 +1,9 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-pyperclip:
   pip.installed:
     - name: pyperclip
-    - upgrade: True
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/pytesseract.sls
+++ b/remnux/python3-packages/pytesseract.sls
@@ -1,9 +1,8 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 pytesseract:
   pip.installed:
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/pyzipper.sls
+++ b/remnux/python3-packages/pyzipper.sls
@@ -1,12 +1,11 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.python3-packages.pycryptodomex
 
 remnux-python3-packages-pyzipper:
   pip.installed:
     - name: pyzipper
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.python3-packages.pycryptodomex

--- a/remnux/python3-packages/qiling.sls
+++ b/remnux/python3-packages/qiling.sls
@@ -7,12 +7,11 @@
 # Notes: Use `qltool` to analyze artifacts. Before analyzing Windows artifacts, gather Windows DLLs and other components using the [dllscollector.bat](https://github.com/qilingframework/qiling/blob/master/examples/scripts/dllscollector.bat) script. Read the tool's [documentation](https://docs.qiling.io) to get started.
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-qiling:
   pip.installed:
     - name: qiling
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/r2pipe.sls
+++ b/remnux/python3-packages/r2pipe.sls
@@ -1,9 +1,8 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 r2pipe:
   pip.installed:
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/ratdecoders.sls
+++ b/remnux/python3-packages/ratdecoders.sls
@@ -7,7 +7,7 @@
 # Notes: malconf
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.packages.git
   - remnux.python3-packages.androguard
   - remnux.python3-packages.yara-python3
@@ -16,9 +16,8 @@ remnux-python3-packages-ratdecoders:
   pip.installed:
     - name: malwareconfig
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.git
       - sls: remnux.python3-packages.androguard
       - sls: remnux.python3-packages.yara-python3

--- a/remnux/python3-packages/setuptools-rust.sls
+++ b/remnux/python3-packages/setuptools-rust.sls
@@ -1,8 +1,9 @@
 include:
   - remnux.python3-packages.pip
 
-pycryptodome==3.9.7:
+remnux-python3-packages-setuptools-rust:
   pip.installed:
+    - name: setuptools_rust
     - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/setuptools.sls
+++ b/remnux/python3-packages/setuptools.sls
@@ -1,9 +1,9 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-setuptools:
   pip.installed:
     - name: setuptools
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/speakeasy.sls
+++ b/remnux/python3-packages/speakeasy.sls
@@ -7,7 +7,7 @@
 # Notes: run_speakeasy.py, emu_exe.py, emu_dll.py
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.packages.git
 
 remnux-python3-packages-speakeasy-requirements:
@@ -15,15 +15,14 @@ remnux-python3-packages-speakeasy-requirements:
     - bin_env: /usr/bin/python3
     - requirements: https://raw.githubusercontent.com/fireeye/speakeasy/master/requirements.txt
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
 
 remnux-python3-packages-speakeasy:
   pip.installed:
     - bin_env: /usr/bin/python3
     - name: git+https://github.com/fireeye/speakeasy.git@master
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.git
       - pip: remnux-python3-packages-speakeasy-requirements
 

--- a/remnux/python3-packages/stpyv8.sls
+++ b/remnux/python3-packages/stpyv8.sls
@@ -17,7 +17,7 @@ include:
   - remnux.packages.libboost-system-dev
   - remnux.packages.libboost-dev
   - remnux.packages.build-essential
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.python3-packages.setuptools
 
 remnux-pip3-stpyv8:
@@ -25,7 +25,7 @@ remnux-pip3-stpyv8:
     - name: https://github.com/area1/stpyv8/releases/download/v8.6.395.10/{{ release }}
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.sudo
       - sls: remnux.packages.libboost-python-dev
       - sls: remnux.packages.libboost-system-dev

--- a/remnux/python3-packages/stringsifter.sls
+++ b/remnux/python3-packages/stringsifter.sls
@@ -7,12 +7,11 @@
 # Notes: flarestrings
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-stringsifter:
   pip.installed:
     - name: stringsifter
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/thug.sls
+++ b/remnux/python3-packages/thug.sls
@@ -8,8 +8,8 @@
 {%- if grains['oscodename'] == "bionic" %}
 include:
   - remnux.packages.git
+  - remnux.python3-packages.pip
   - remnux.python3-packages.setuptools
-  - remnux.packages.python3-pip
   - remnux.packages.libemu
   - remnux.packages.libgraphviz-dev
   - remnux.packages.libxml2-dev
@@ -25,9 +25,9 @@ include:
 {%- elif grains['oscodename'] == "focal" %}
 include:
   - remnux.packages.git
+  - remnux.python3-packages.pip
   - remnux.python3-packages.setuptools
   - remnux.python3-packages.pygraphviz
-  - remnux.packages.python3-pip
   - remnux.packages.libemu
   - remnux.packages.libgraphviz-dev
   - remnux.packages.libxml2-dev
@@ -51,9 +51,8 @@ remnux-python3-packages-thug:
   pip.installed:
     - name: thug
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
     - watch:
       - git: remnux-python3-packages-git-thug
 

--- a/remnux/python3-packages/time-decode.sls
+++ b/remnux/python3-packages/time-decode.sls
@@ -7,12 +7,11 @@
 # Notes: time_decode.py
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-time-decode:
   pip.installed:
     - name: time-decode
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/unfurl.sls
+++ b/remnux/python3-packages/unfurl.sls
@@ -8,7 +8,7 @@
 
 include:
   - remnux.python3-packages.protobuf
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.packages.git
 
 remnux-python3-packages-unfurl-requirements:
@@ -16,15 +16,14 @@ remnux-python3-packages-unfurl-requirements:
     - bin_env: /usr/bin/python3
     - requirements: https://raw.githubusercontent.com/obsidianforensics/unfurl/master/requirements.txt
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.python3-packages.protobuf
 
 remnux-python3-packages-unfurl:
   pip.installed:
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - name: git+https://github.com/obsidianforensics/unfurl.git@master
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.git
       - pip: remnux-python3-packages-unfurl-requirements

--- a/remnux/python3-packages/unicode.sls
+++ b/remnux/python3-packages/unicode.sls
@@ -7,13 +7,12 @@
 # Notes: 
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-unicode:
   pip.installed:
     - name: unicode
-    - upgrade: True
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
 

--- a/remnux/python3-packages/upgrade.sls
+++ b/remnux/python3-packages/upgrade.sls
@@ -1,34 +1,112 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
+  - remnux.python3-packages.androguard
+  - remnux.python3-packages.cffi
   - remnux.python3-packages.chepy
+  - remnux.python3-packages.colorama
+  - remnux.python3-packages.dc3-mwcp
+  - remnux.python3-packages.docker-compose
+  - remnux.python3-packages.droidlysis
+  - remnux.python3-packages.fakemail
+  - remnux.python3-packages.frida
+  - remnux.python3-packages.hachoir
+  - remnux.python3-packages.ipwhois
+  - remnux.python3-packages.jsbeautifier
   - remnux.python3-packages.malwoverview
   - remnux.python3-packages.msoffcrypto-tool
+  - remnux.python3-packages.name-that-hash
   - remnux.python3-packages.olefile
   - remnux.python3-packages.oletools
   - remnux.python3-packages.pcodedmp
+  - remnux.python3-packages.pe-tree
+  - remnux.python3-packages.pefile
   - remnux.python3-packages.peframe
   - remnux.python3-packages.protobuf
+  - remnux.python3-packages.pyelftools
+  - remnux.python3-packages.pygraphviz
+  - remnux.python3-packages.pylzma
+  - remnux.python3-packages.pyperclip
+  - remnux.python3-packages.pytesseract
+  - remnux.python3-packages.pyzipper
+  - remnux.python3-packages.qiling
+  - remnux.python3-packages.r2pipe
+  - remnux.python3-packages.ratdecoders
   - remnux.python3-packages.setuptools
+  - remnux.python3-packages.setuptools-rust
+  - remnux.python3-packages.stringsifter
+  - remnux.python3-packages.thug
+  - remnux.python3-packages.time-decode
+  - remnux.python3-packages.unicode
   - remnux.python3-packages.wheel
+  - remnux.python3-packages.xlmmacrodeobfuscator
+  - remnux.python3-packages.xortool
+  - remnux.python3-packages.yara-python3
 
 remnux-python3-packages-pypi-upgrade:
   cmd.run:
-    - name: /usr/bin/python3 -m pip install --upgrade chepy chepy[extras] msoffcrypto-tool olefile oletools pcodedmp protobuf setuptools wheel peframe-ds
+    - name: /usr/bin/python3 -m pip install --upgrade androguard cffi chepy chepy[extras] colorama mwcp docker-compose droidlysis fakemail frida-tools hachoir ipwhois jsbeautifier msoffcrypto-tool olefile oletools pcodedmp pe_tree pefile protobuf pyelftools pygraphviz pylzma pyperclip pytesseract pyzipper qiling r2pipe malwareconfig setuptools setuptools_rust stringsifter thug time-decode unicode wheel peframe-ds xlmmacrodeobfuscator xortool yara-python
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
+      - sls: remnux.python3-packages.androguard
+      - sls: remnux.python3-packages.cffi
       - sls: remnux.python3-packages.chepy
+      - sls: remnux.python3-packages.colorama
+      - sls: remnux.python3-packages.dc3-mwcp
+      - sls: remnux.python3-packages.docker-compose
+      - sls: remnux.python3-packages.droidlysis
+      - sls: remnux.python3-packages.fakemail
+      - sls: remnux.python3-packages.frida
+      - sls: remnux.python3-packages.hachoir
+      - sls: remnux.python3-packages.ipwhois
+      - sls: remnux.python3-packages.jsbeautifier
+      - sls: remnux.python3-packages.malwoverview
       - sls: remnux.python3-packages.msoffcrypto-tool
+      - sls: remnux.python3-packages.name-that-hash
       - sls: remnux.python3-packages.olefile
       - sls: remnux.python3-packages.oletools
       - sls: remnux.python3-packages.pcodedmp
+      - sls: remnux.python3-packages.pe-tree
+      - sls: remnux.python3-packages.pefile
       - sls: remnux.python3-packages.peframe
       - sls: remnux.python3-packages.protobuf
+      - sls: remnux.python3-packages.pyelftools
+      - sls: remnux.python3-packages.pygraphviz
+      - sls: remnux.python3-packages.pylzma
+      - sls: remnux.python3-packages.pyperclip
+      - sls: remnux.python3-packages.pytesseract
+      - sls: remnux.python3-packages.pyzipper
+      - sls: remnux.python3-packages.qiling
+      - sls: remnux.python3-packages.r2pipe
+      - sls: remnux.python3-packages.ratdecoders
       - sls: remnux.python3-packages.setuptools
+      - sls: remnux.python3-packages.setuptools-rust
+      - sls: remnux.python3-packages.stringsifter
+      - sls: remnux.python3-packages.thug
+      - sls: remnux.python3-packages.time-decode
+      - sls: remnux.python3-packages.unicode
       - sls: remnux.python3-packages.wheel
+      - sls: remnux.python3-packages.xlmmacrodeobfuscator
+      - sls: remnux.python3-packages.xortool
+      - sls: remnux.python3-packages.yara-python3
 
 remnux-python3-packages-malwoverview-upgrade:
   cmd.run:
     - name: /opt/malwoverview/bin/python3 -m pip install --upgrade malwoverview
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.python3-packages.malwoverview
+
+{%- if grains['oscodename'] == "focal" %}
+
+remnux-python3-packages-upgrade-nth:
+  cmd.run:
+    - name: /usr/bin/python3 -m pip install --upgrade name-that-hash
+    - require:
+      - sls: remnux.python3-packages.pip
+
+{%- elif grains['oscodename'] == "bionic" %}
+
+remnux-python3-packages-no-nth-to-upgrade:
+  test.nop
+
+{%- endif -%}

--- a/remnux/python3-packages/viper-framework.sls
+++ b/remnux/python3-packages/viper-framework.sls
@@ -27,7 +27,7 @@ include:
   - remnux.packages.libfuzzy-dev
   - remnux.packages.git
   - remnux.packages.virtualenv
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.packages.python3-virtualenv
   - remnux.packages.python3-venv
   - remnux.packages.build-essential
@@ -50,7 +50,7 @@ remnux-python3-packages-viper-virtualenv:
       - setuptools
       - wheel
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.python3-virtualenv
       - sls: remnux.packages.python3-venv
       - sls: remnux.packages.virtualenv
@@ -65,7 +65,7 @@ remnux-python3-packages-viper-install:
       - sls: remnux.packages.libusb-1
       - sls: remnux.packages.libfuzzy-dev
       - sls: remnux.packages.git
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.build-essential
       - sls: remnux.packages.libffi-dev
       - sls: remnux.packages.unrar
@@ -145,7 +145,6 @@ remnux-python3-packages-viper-modules-update:
 remnux-python3-packages-viper-modules-requirements:
   pip.installed:
     - requirements: {{ home }}/.viper/modules/requirements.txt
-    - upgrade: True
     - bin_env: /opt/viper/bin/pip3
     - require:
       - file: remnux-python3-packages-viper-modules-verify-sigs

--- a/remnux/python3-packages/virustotal-api.sls
+++ b/remnux/python3-packages/virustotal-api.sls
@@ -7,15 +7,14 @@
 # Notes: vt
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.packages.git
 
 remnux-python3-package-virustotal-api:
   pip.installed:
     - name: git+https://github.com/doomedraven/VirusTotalApi
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.packages.git
 

--- a/remnux/python3-packages/volatility3.sls
+++ b/remnux/python3-packages/volatility3.sls
@@ -9,16 +9,15 @@
 include:
   - remnux.packages.git
   - remnux.python3-packages.pefile
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-volatility3:
   pip.installed:
     - name: git+https://github.com/volatilityfoundation/volatility3.git
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
       - sls: remnux.packages.git
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.python3-packages.pefile
 
 remnux-python3-packages-volatility-rename-vol:

--- a/remnux/python3-packages/wheel.sls
+++ b/remnux/python3-packages/wheel.sls
@@ -1,9 +1,9 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-wheel:
   pip.installed:
-    - name: wheel
+    - name: wheel==0.36.2
     - bin_env: /usr/bin/python3
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/xlmmacrodeobfuscator.sls
+++ b/remnux/python3-packages/xlmmacrodeobfuscator.sls
@@ -7,15 +7,14 @@
 # Notes: xlmdeobfuscator
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python3-packages-xlmmacrodeobfuscator:
   pip.installed:
     - name: xlmmacrodeobfuscator
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
 
 /usr/local/bin/runxlrd2.py:
   file.managed:

--- a/remnux/python3-packages/xortool.sls
+++ b/remnux/python3-packages/xortool.sls
@@ -7,11 +7,10 @@
 # Notes: 
 
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 xortool:
   pip.installed:
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/xxxswf.sls
+++ b/remnux/python3-packages/xxxswf.sls
@@ -8,7 +8,7 @@
 
 include:
   - remnux.packages.git
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
   - remnux.python3-packages.yara-python3
   - remnux.python3-packages.pylzma
 
@@ -16,9 +16,8 @@ remnux-python3-packages-xxxswf:
   pip.installed:
     - name: git+https://github.com/viper-framework/xxxswf.git
     - bin_env: /usr/bin/python3
-#    - upgrade: True
     - require:
       - sls: remnux.packages.git
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip
       - sls: remnux.python3-packages.yara-python3
       - sls: remnux.python3-packages.pylzma

--- a/remnux/python3-packages/yara-python3.sls
+++ b/remnux/python3-packages/yara-python3.sls
@@ -1,10 +1,9 @@
 include:
-  - remnux.packages.python3-pip
+  - remnux.python3-packages.pip
 
 remnux-python-packages-yara-python3:
   pip.installed:
     - name: "yara-python"
     - bin_env: /usr/bin/python3
-    - upgrade: True
     - require:
-      - sls: remnux.packages.python3-pip
+      - sls: remnux.python3-packages.pip

--- a/remnux/tools/flare.sls
+++ b/remnux/tools/flare.sls
@@ -9,7 +9,7 @@
 remnux-tools-flare-source:
   file.managed:
     - name: /usr/local/src/remnux/files/flare06linux64.tgz
-    - source: https://www.nowrap.de/download/flare06linux64.tgz
+    - source: http://www.nowrap.de/download/flare06linux64.tgz
     - source_hash: c83ecd7836298e4f6a3258c2a8428f78d91ef58f142b0251f013a2746ede50e6
     - makedirs: True
 

--- a/remnux/tools/flasm.sls
+++ b/remnux/tools/flasm.sls
@@ -12,7 +12,7 @@ include:
 remnux-tools-flasm-source:
   file.managed:
     - name: /usr/local/src/remnux/files/flasm16linux.tgz
-    - source: https://www.nowrap.de/download/flasm16linux.tgz
+    - source: http://www.nowrap.de/download/flasm16linux.tgz
     - source_hash: 88f16edcdee60773828107e6af16265a21bd577cf6acbf374c7864d2b58d43cb
     - makedirs: True
     - require:


### PR DESCRIPTION
Multiple changes to fix existing python3-pip errors and prevent future ones:
- since python3 pip requires upgrading for some states, and is already upgraded in `remnux.python3-packages.pip.sls`, all python3-packages now utilize that state instead of the `remnux.packages.python3-pip`.
- python3 pip is pinned at current version for both focal and bionic to start, which is `21.0.1`
- added setuptools_rust, as some newer pip packages are now requiring it (msoffcrypto and docker-compose right now, due to the cryptography package requirements)
- removed `upgrade: True` from all python3 states and added all python3 states (which require upgrading) to upgrade.sls to ensure all packages get upgraded on each install when applicable. The `upgrade: True` issue is a result of pip no longer supporting the search feature, thus not allowing for pip to match current version with a list of versions available

