### PR TITLE
Fix nodejs not upgrading existing node install

### DIFF
--- a/remnux/packages/nodejs.sls
+++ b/remnux/packages/nodejs.sls
@@ -2,4 +2,4 @@ include:
   - remnux.repos.nodejs
 
 nodejs:
-  pkg.installed
+  pkg.latest


### PR DESCRIPTION
This will fix the issue identified in [remnux-cli/#27](https://github.com/REMnux/remnux-cli/issues/27) where the existing nodejs installation from the SIFT-Workstation VM was not upgraded using the nodejs packed with the remnux installer. Changed the state to `pkg.latest` vice `pkg.installed` to confirm that the latest package would be available (which comes with npm, which was the cause of the issue referenced above).
