### PR TITLE
Temp fix for pefile install issues

### DIFF
--- a/remnux/python-packages/pefile.sls
+++ b/remnux/python-packages/pefile.sls
@@ -9,11 +9,13 @@
 include:
   - remnux.packages.python2-pip
   - remnux.packages.python3-pip
+  - remnux.packages.git
 
 remnux-python-packages-pefile:
   pip.installed:
-    - name: pefile
+    - name: git+https://github.com/digitalsleuth/pefile.git
     - bin_env: /usr/bin/python2
     - upgrade: True
     - require:
       - sls: remnux.packages.python2-pip
+      - sls: remnux.packages.git


### PR DESCRIPTION
This change points the install for pefile temporarily to https://github.com/digitalsleuth/pefile. The original source for pefile has a formatting issue with f-strings, which are not python2 compatible, and these prevent the setup from completing successfully.

Source issue is tracked  [here](https://github.com/erocarrera/pefile/issues/318) with a pull request submitted to the author [here](https://github.com/erocarrera/pefile/pull/319) proposing a solution.

Once the original author fixes the issue, we can point the state file back to the original source.