### PR TITLE
Fix for cloud installation

### DIFF
--- a/remnux/python3-packages/vivisect.sls
+++ b/remnux/python3-packages/vivisect.sls
@@ -12,6 +12,12 @@ include:
 
 {%- if grains['oscodename'] == "focal" %}
 
+remnux-python3-packages-vivisect-pyasn1-removal:
+  pkg.removed:
+    - pkgs:
+      - python3-pyasn1
+      - python3-pyasn1-modules
+
 remnux-python3-packages-vivisect-cleanup1:
   module.run:
     - name: file.find


### PR DESCRIPTION
Cloud Images/AMI's seem to come with python3-pyasn1 and python3-pyasn1-modules installed via APT package manager instead of pip. Thus, when installing the requirements for vivisect (ie: specific versions of pyasn1) the installer fails thinking it was a distutils project and can't be uninstalled, since there is no way to determine what files came with the packages.

To address this issue, I've added a requirement for those two APT packages to be removed prior to the installation of vivisect (the original source of the pyasn issue). 