### PR TITLE
Fix for YAML issues, removed cleanup

### DIFF
--- a/remnux/python3-packages/capa.sls
+++ b/remnux/python3-packages/capa.sls
@@ -13,30 +13,13 @@ include:
 
 {%- if grains['oscodename'] == "focal" %}
 
-
-remnux-python3-packages-capa-cleanup1:
-  module.run:
-    - name: file.find
-    - path: "/usr/lib/python3/dist-packages"
-    - kwargs:
-        iname: "PyYAML-*.egg-info"
-        delete: "f"
-    - require:
-      - sls: remnux.python3-packages.vivisect
-
-remnux-python3-packages-capa-cleanup2:
-  file.absent:
-    - name: /usr/lib/python3/dist-packages/yaml
-    - require:
-      - module: remnux-python3-packages-capa-cleanup1
-
-remnux-python3-packages-capa-cleanup3:
+remnux-python3-packages-capa-yaml:
   pip.installed:
     - bin_env: /usr/bin/python3
     - name: pyyaml
+    - ignore_installed: True
     - require:
       - sls: remnux.python3-packages.pip
-      - file: remnux-python3-packages-capa-cleanup2
 
 remnux-python3-packages-capa:
   pip.installed:
@@ -44,7 +27,7 @@ remnux-python3-packages-capa:
     - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.python3-packages.pip
-      - pip: remnux-python3-packages-capa-cleanup3
+      - pip: remnux-python3-packages-capa-yaml
 
 {%- else %}
 

--- a/remnux/python3-packages/vivisect.sls
+++ b/remnux/python3-packages/vivisect.sls
@@ -18,35 +18,13 @@ remnux-python3-packages-vivisect-pyasn1-removal:
       - python3-pyasn1
       - python3-pyasn1-modules
 
-remnux-python3-packages-vivisect-cleanup1:
-  module.run:
-    - name: file.find
-    - path: "/usr/lib/python3/dist-packages"
-    - kwargs:
-        iname: "PyYAML-*.egg-info"
-        delete: "f"
-
-remnux-python3-packages-vivisect-cleanup2:
-  file.absent:
-    - name: /usr/lib/python3/dist-packages/yaml
-    - require:
-      - module: remnux-python3-packages-vivisect-cleanup1
-
-remnux-python3-packages-vivisect-cleanup3:
-  pip.installed:
-    - bin_env: /usr/bin/python3
-    - name: pyyaml
-    - require:
-      - sls: remnux.python3-packages.pip
-      - file: remnux-python3-packages-vivisect-cleanup2
-
 remnux-python3-packages-vivisect:
   pip.installed:
     - bin_env: /usr/bin/python3
     - name: vivisect
     - require:
       - sls: remnux.python3-packages.pip
-      - pip: remnux-python3-packages-vivisect-cleanup3
+      - pkg: remnux-python3-packages-vivisect-pyasn1-removal
 
 {%- else %}
 


### PR DESCRIPTION
I realize this branch/PR is named incorrectly, but this is to fix the PyYAML issues and cleanup the temporary fixes.

Added the "ignore_installed: True" flag to the pyyaml package so that pyyaml will install and not try to remove the PyYAML installed by saltstack (5.3.1). This does not impede the installation or usage of salt, just upgrades the version of YAML to be used.

Did not add the "ignore_installed" to the capa install as a whole, because we don't want to affect the upgrade/versioning of the other python packages which get installed as a requirement.