### PR TITLE
pefile updated at source, returning to normal state

### DIFF
--- a/remnux/python-packages/pefile.sls
+++ b/remnux/python-packages/pefile.sls
@@ -9,13 +9,11 @@
 include:
   - remnux.packages.python2-pip
   - remnux.packages.python3-pip
-  - remnux.packages.git
 
 remnux-python-packages-pefile:
   pip.installed:
-    - name: git+https://github.com/digitalsleuth/pefile.git
+    - name: pefile
     - bin_env: /usr/bin/python2
     - upgrade: True
     - require:
       - sls: remnux.packages.python2-pip
-      - sls: remnux.packages.git


### PR DESCRIPTION
The author of pefile has decided to stop supporting Python 2, and yanked the 2021.5.13 release which was being installed. The newest release is python3 only, thus when installing via python 2 pip, the latest python 2 version (from 2019) is now installed.