### PR TITLE
Fix for vipermonkey install on 20.04

### DIFF
--- a/remnux/python-packages/vipermonkey.sls
+++ b/remnux/python-packages/vipermonkey.sls
@@ -11,6 +11,7 @@ include:
   - remnux.packages.git
   - remnux.packages.virtualenv
   - remnux.packages.python3-pip
+  - remnux.packages.python2-dev
 
 remnux-python-packages-vipermonkey-virtualenv:
   virtualenv.managed:
@@ -27,11 +28,12 @@ remnux-python-packages-vipermonkey-virtualenv:
 
 remnux-python-packages-vipermonkey-install:
   pip.installed:
-    - editable: git+https://github.com/decalage2/ViperMonkey.git#egg=ViperMonkey
+    - name: git+https://github.com/decalage2/ViperMonkey.git
     - bin_env: /opt/vipermonkey/bin/python
     - require:
       - sls: remnux.packages.git
       - sls: remnux.packages.python2-pip
+      - sls: remnux.packages.python2-dev
       - virtualenv: remnux-python-packages-vipermonkey-virtualenv
 
 remnux-python-packages-vipermonkey-symlink:


### PR DESCRIPTION
The python2-dev state was missing from the requirements for vipermonkey, and installing the pip package in a standard method vice editable resolves the issues.

Some recent updates to the regex package requires python2-dev to build, without it, the build was failing.
