### PR TITLE
Fix for pefile install on Bionic

### DIFF
--- a/remnux/python-packages/pefile.sls
+++ b/remnux/python-packages/pefile.sls
@@ -12,7 +12,7 @@ include:
 
 remnux-python-packages-pefile:
   pip.installed:
-    - name: pefile
+    - name: pefile==2019.4.18
     - bin_env: /usr/bin/python2
     - upgrade: True
     - require:


### PR DESCRIPTION
In order to properly install pefile on bionic, the version needs to be specified. It is still attempting to install the yanked version of pefile (2021.5.13) vice the last supported Python2.7 version, which was 2019.4.18.

Pinned the install to the specific version, which will allow the install to complete on bionic, and not affect the install on focal.