### PR TITLE
Update NetworkMiner hash and cleanup

### DIFF
--- a/remnux/tools/networkminer.sls
+++ b/remnux/tools/networkminer.sls
@@ -11,9 +11,9 @@ include:
 
 remnux-networkminer-source:
   file.managed:
-    - name: /usr/local/src/remnux/files/networkminer-2.6.zip
+    - name: /usr/local/src/remnux/files/networkminer-2.7.1.zip
     - source: https://www.netresec.com/?download=NetworkMiner
-    - source_hash: sha256=34d81e42eec33183b79191de165ae506933fa3bb5b1fd836e70ef81468c9c65b
+    - source_hash: sha256=df4057eb0256dab23dee9c248d60db11d46b20d344d8769ca0e5768afd76dd3f
     - makedirs: True
     - replace: False
     - require:
@@ -22,13 +22,13 @@ remnux-networkminer-source:
 remnux-networkminer-archive:
   archive.extracted:
     - name: /usr/local/
-    - source: /usr/local/src/remnux/files/networkminer-2.6.zip
+    - source: /usr/local/src/remnux/files/networkminer-2.7.1.zip
     - enforce_toplevel: True
     - force: true
     - watch:
       - file: remnux-networkminer-source
 
-/usr/local/NetworkMiner_2-6/NetworkMiner.exe:
+/usr/local/NetworkMiner_2-7-1/NetworkMiner.exe:
   file.managed:
     - mode: 755
     - replace: False
@@ -41,13 +41,15 @@ remnux-networkminer-wrapper:
     - mode: 755
     - replace: True
     - watch:
-        - file: /usr/local/NetworkMiner_2-6/NetworkMiner.exe
+        - file: /usr/local/NetworkMiner_2-7-1/NetworkMiner.exe
     - contents:
       - '#!/bin/bash'
-      - mono /usr/local/NetworkMiner_2-6/NetworkMiner.exe ${*}
+      - mono /usr/local/NetworkMiner_2-7-1/NetworkMiner.exe ${*}
 
-remnux-networkminer-cleanup-2-5:
+remnux-networkminer-cleanup:
   file.absent:
-    - name: /usr/local/NetworkMiner_2-5
+    - names: 
+      - /usr/local/NetworkMiner_2-5
+      - /usr/local/NetworkMiner_2-6
     - require:
       - file: remnux-networkminer-wrapper


### PR DESCRIPTION
Updated hash, version, and cleanup of NetworkMiner. Resolves one of the issues in [Issue #36](https://github.com/REMnux/remnux-cli/issues/36) at remnux-cli.
