### PR TITLE
Make vivisect remove pyasn1-modules for focal and bionic

### DIFF
--- a/remnux/python3-packages/vivisect.sls
+++ b/remnux/python3-packages/vivisect.sls
@@ -18,8 +18,6 @@ remnux-python3-packages-vivisect-pyqt:
     - require:
       - sls: remnux.python3-packages.pip
 
-{%- if grains['oscodename'] == "focal" %}
-
 remnux-python3-packages-vivisect-pyasn1-removal:
   pkg.removed:
     - pkgs:
@@ -33,17 +31,6 @@ remnux-python3-packages-vivisect:
     - require:
       - pip: remnux-python3-packages-vivisect-pyqt
       - pkg: remnux-python3-packages-vivisect-pyasn1-removal
-
-{%- else %}
-
-remnux-python3-packages-vivisect:
-  pip.installed:
-    - bin_env: /usr/bin/python3
-    - name: vivisect
-    - require:
-      - pip: remnux-python3-packages-vivisect-pyqt
-
-{%- endif %}
 
 remnux-python3-packages-vivisect-cleanup:
   pip.removed:


### PR DESCRIPTION
Turns out the bionic install also requires python3-pyasn1* packages to be removed to achieve a successful install in WSL2. Even though Ubuntu 20.04 is the primary support OS at this time, this change causes no impact to its support, and enables a successful install in both 18.04 and 20.04 for the prime Ubuntu OS and the WSL versions.

This has been tested in fresh 18/20 WSL 2 environs, as well as the standard Ubuntu docker tests. This should rectify the last of the issues from [Issue #36](https://github.com/REMnux/remnux-cli/issues/36).