### PR TITLE
Unidecode version pinned to resolve Issue 42

### DIFF
--- a/remnux/python-packages/vipermonkey.sls
+++ b/remnux/python-packages/vipermonkey.sls
@@ -38,6 +38,14 @@ remnux-python-packages-vipermonkey-virtualenv:
       - sls: remnux.packages.python2-pip
       - sls: remnux.packages.virtualenv
 
+remnux-python-packages-vipermonkey-unidecode:
+  pip.installed:
+    - name: unidecode==1.2.0
+    - bin_env: /opt/vipermonkey/bin/python
+    - require:
+      - sls: remnux.packages.python2-pip
+      - sls: remnux.packages.python2-dev
+
 {%- if grains['oscodename'] == "focal" %}
 
 remnux-python-packages-vipermonkey-install:
@@ -48,6 +56,7 @@ remnux-python-packages-vipermonkey-install:
       - sls: remnux.packages.git
       - sls: remnux.packages.python2-pip
       - sls: remnux.packages.python2-dev
+      - pip: remnux-python-packages-vipermonkey-unidecode
       - virtualenv: remnux-python-packages-vipermonkey-virtualenv
 
 {%- else %}
@@ -59,6 +68,7 @@ remnux-python-packages-vipermonkey-install:
     - require:
       - sls: remnux.packages.git
       - sls: remnux.packages.python2-pip
+      - pip: remnux-python-packages-vipermonkey-unidecode
       - virtualenv: remnux-python-packages-vipermonkey-virtualenv
 
 {%- endif %}


### PR DESCRIPTION
This resolves Issue [#42](https://github.com/REMnux/remnux-cli/issues/42) where install was failing due to ViperMonkey's dependency unidecode not meeting the min Python requirement of Python 3.x.

Unidecode was recently upgraded from 1.2.0 to 1.3.0, where 1.3.0 no longer supports Python 2. Since there is no Py3 version of ViperMonkey available yet, I've pinned unidecode to 1.2.0 to continue supporting ViperMonkey while a Python3 version is being tested.