### PR TITLE
Modified nodejs repo #196

### DIFF
--- a/remnux/repos/nodejs.sls
+++ b/remnux/repos/nodejs.sls
@@ -1,8 +1,8 @@
 nodejs-repo:
   pkgrepo.managed:
     - humanname: nodejs
-    - name: deb https://deb.nodesource.com/node_14.x {{ grains['lsb_distrib_codename'] }} main
+    - name: deb http://deb.nodesource.com/node_14.x {{ grains['lsb_distrib_codename'] }} main
     - file: /etc/apt/sources.list.d/nodesource.list
-    - key_url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    - key_url: http://deb.nodesource.com/gpgkey/nodesource.gpg.key
     - gpgcheck: 1
     - refresh: true


### PR DESCRIPTION
Nodejs repo currently has a failing certificate, causing `apt` to not be able to update and preventing installation of apt-based utilities. Replacing `https` with `http` in the nodejs.sls state resolves this issue and allows the install to continue. Additional details can be found in the referenced issue.