### PR TITLE
Update polarproxy hash and version

### DIFF
--- a/remnux/tools/polarproxy.sls
+++ b/remnux/tools/polarproxy.sls
@@ -8,16 +8,16 @@
 
 remnux-polarproxy-source:
   file.managed:
-    - name: /usr/local/src/remnux/files/PolarProxy_0-8-16_linux-x64.tar
+    - name: /usr/local/src/remnux/files/PolarProxy_0-9-0_linux-x64.tar.gz
     - source: https://www.netresec.com/?download=PolarProxy
-    - source_hash: sha256=9c0bef3bff91ef66f70daf91a423829104728f99d0a2a52bbc13a5c1d7ed60b8
+    - source_hash: sha256=7018ed331bed230fc1c3cf6accece2e925968361a7dcc8fe8725890636b57a21
     - makedirs: True
     - replace: False
 
 remnux-polarproxy-archive:
   archive.extracted:
     - name: /usr/local/polarproxy/
-    - source: /usr/local/src/remnux/files/PolarProxy_0-8-16_linux-x64.tar
+    - source: /usr/local/src/remnux/files/PolarProxy_0-9-0_linux-x64.tar.gz
     - enforce_toplevel: False
     - force: true
     - watch:


### PR DESCRIPTION
Regarding [issue 58 ](https://github.com/REMnux/remnux-cli/issues/58), updated the polarproxy hash and version number. File is now a tar.gz vice just a tar.