### PR TITLE
Adding msitools to REMnux

### DIFF
--- a/remnux/packages/msitools.sls
+++ b/remnux/packages/msitools.sls
@@ -1,0 +1,10 @@
+# Name: msitools
+# Website: https://wiki.gnome.org/msitools
+# Description: Windows Installer file manipulation tool msitools contains a number of programs to create, inspect and extract Windows Installer (.msi) files.
+# Category: Examine Static Properties: MSI Files 
+# Author: Stephen Kitt
+# License: GNU Lesser General Public License v2.1: https://gitlab.gnome.org/GNOME/msitools/-/blob/master/copyright
+# Notes: 
+
+msitools:
+  pkg.installed


### PR DESCRIPTION
Thank you for all the work y'all have done on this amazing distro :heart: 

Adding msitools to the distro will help accelerate malware analysis of MSI files without having to rely on oledump and some spotty 7z  things.