### PR TITLE
Fix jinja issues during remnux update/upgrade

### DIFF
--- a/remnux/python3-packages/init.sls
+++ b/remnux/python3-packages/init.sls
@@ -48,6 +48,7 @@ include:
   - remnux.python3-packages.pcode2code
   - remnux.python3-packages.mail-parser
   - remnux.python3-packages.csce
+  - remnux.python3-packages.jinja2
 
 remnux-python3-packages:
   test.nop:
@@ -101,3 +102,4 @@ remnux-python3-packages:
       - sls: remnux.python3-packages.pcode2code
       - sls: remnux.python3-packages.mail-parser
       - sls: remnux.python3-packages.csce
+      - sls: remnux.python3-packages.jinja2

--- a/remnux/python3-packages/jinja2.sls
+++ b/remnux/python3-packages/jinja2.sls
@@ -1,0 +1,8 @@
+include:
+  - remnux.python3-packages.pip
+
+jinja2==3.0.3:
+  pip.installed:
+    - bin_env: /usr/bin/python3
+    - require:
+      - sls: remnux.python3-packages.pip


### PR DESCRIPTION
As indicated in [Issue #67](https://github.com/REMnux/remnux-cli/issues/67), there is an issue with Jinja2 being upgraded during the remnux install and update/upgrade. This is also reported [here](https://github.com/saltstack/salt/issues/61848) at the Saltstack repo. 

To mitigate this issue, I've created a state at the end of the python3-packages states to pin jinja2 at 3.0.3 (as recommended in the salt issue). Tested in both docker and live environments without issue.