### PR TITLE
Update Radare2 based on recent CVE news

### DIFF
--- a/remnux/packages/radare2.sls
+++ b/remnux/packages/radare2.sls
@@ -5,21 +5,22 @@
 # Author: https://github.com/radareorg/radare2/blob/master/AUTHORS.md
 # License: GNU Lesser General Public License (LGPL) v3: https://github.com/radareorg/radare2/blob/master/COPYING
 # Notes: r2, rasm2, rabin2, rahash2, rafind2
+{% set version = '5.6.8' %}
+{% set hash = '7af2fa605f00e1ae740db7dba2c0b8bc6c44e2eea3027cc7795ec46bf0292d2e' %}
 
 include:
   - remnux.packages.git
 
 remnux-radare2-source:
   file.managed:
-    - name: /usr/local/src/radare2_4.3.1_amd64.deb
-    - source: http://radare.mikelloc.com/get/4.3.1/radare2_4.3.1_amd64.deb
-    - source_hash: sha256=d72170c5dcfdc10eed604f9e33b2868107aee6db564152eb63cab78b1d066aa7
-
+    - name: /usr/local/src/radare2_{{ version }}_amd64.deb
+    - source: https://github.com/radareorg/radare2/releases/download/{{ version }}/radare2_{{ version }}_amd64.deb
+    - source_hash: sha256={{ hash }}
 
 remnux-radare2:
   pkg.installed:
     - sources:
-      - radare2: /usr/local/src/radare2_4.3.1_amd64.deb
+      - radare2: /usr/local/src/radare2_{{ version }}_amd64.deb
     - watch:
       - file: remnux-radare2-source
     - require:


### PR DESCRIPTION
A recent news article from [Census Labs](https://census-labs.com/news/2022/05/24/multiple-vulnerabilities-in-radare2/) referred to some discovered vulnerabilities in Radare2. This PR will update Radare2 to 5.6.8 (latest version), which is in line with the recommendation of updating to version 5.6.0 or later.