### PR TITLE
Bump capa version to 3.2.0

### DIFF
--- a/remnux/tools/capa.sls
+++ b/remnux/tools/capa.sls
@@ -8,15 +8,15 @@
 
 remnux-tools-capa-source:
   file.managed:
-    - name: /usr/local/src/remnux/files/capa-v2.0.0-linux.zip
-    - source: https://github.com/fireeye/capa/releases/download/v2.0.0/capa-v2.0.0-linux.zip
-    - source_hash: 3377410ee0c01df9e96d770e23796236e26b30192ab9016a2994e65e185d9497
+    - name: /usr/local/src/remnux/files/capa-v3.2.0-linux.zip
+    - source: https://github.com/mandiant/capa/releases/download/v3.2.0/capa-v3.2.0-linux.zip
+    - source_hash: 8d180d0abd75033bdce1071747a54bb6d16f558e15e0d39d443e421c81163e9f
     - makedirs: True
 
 remnux-tools-capa-archive:
   archive.extracted:
-    - name: /usr/local/src/remnux/capa-v2.0.0-linux
-    - source: /usr/local/src/remnux/files/capa-v2.0.0-linux.zip
+    - name: /usr/local/src/remnux/capa-v3.2.0-linux
+    - source: /usr/local/src/remnux/files/capa-v3.2.0-linux.zip
     - enforce_toplevel: False
     - require:
       - file: remnux-tools-capa-source
@@ -24,7 +24,7 @@ remnux-tools-capa-archive:
 remnux-tools-capa-binary:
   file.managed:
     - name: /usr/local/bin/capa
-    - source: /usr/local/src/remnux/capa-v2.0.0-linux/capa
+    - source: /usr/local/src/remnux/capa-v3.2.0-linux/capa
     - mode: 755
     - require:
       - archive: remnux-tools-capa-archive


### PR DESCRIPTION
Moving version up to 3.2.0 gets additional support for ELF binaries, loads of new rules, and performance enhancements.