### PR TITLE
Change default source for .malwapi.conf file

### DIFF
--- a/remnux/python3-packages/malwoverview.sls
+++ b/remnux/python3-packages/malwoverview.sls
@@ -56,7 +56,7 @@ remnux-python3-packages-malwoverview-install:
 remnux-python3-packages-malwoverview-config-file:
   file.managed:
     - name: {{ home }}/.malwapi.conf
-    - source: /opt/malwoverview/lib/{{ python3_version }}/site-packages/home/{{ user }}/.malwapi.conf
+    - source: /opt/malwoverview/lib/{{ python3_version }}/site-packages/home/remnux/.malwapi.conf
     - user: {{ user }}
     - group: {{ user }}
     - makedirs: False


### PR DESCRIPTION
In the [setup.py](https://github.com/alexandreborges/malwoverview/blob/master/setup.py) file for malwoverview, there is a variable which defines the users home directory (`USER_HOME_DIR = str(Path.home()) + os.sep`) to place the .malwapi.conf file. 

When using the venv, this typically **SHOULD** place the conf file in /opt/malwoverview/lib/python3.8/site-packages/home/{{ user }} folder. However, because the pip.installed command is run without a user defined, and the `set user` jinja sets the default user as `remnux`, the pip.installed command is run as user `remnux`. This creates the .malwapi.conf file in the `../home/remnux/` folder instead of the actual user.

When a user not defined during the install process, the previous config would succeed, since the default user to create is `remnux`. But if a user is defined, the pillar changes, but the `pip.installed` part of the state doesn't take into account the user defined in the pillar.

The quickest / easiest solution to fix the [issue defined in REMnux-cli/issues/#87](https://github.com/REMnux/remnux-cli/issues/87) is to change the source to `remnux` vice `{{ user }}` since this will always be correct.