### PR TITLE
Fix unfurl repo branch pointer

### DIFF
--- a/remnux/python3-packages/unfurl.sls
+++ b/remnux/python3-packages/unfurl.sls
@@ -14,7 +14,7 @@ include:
 remnux-python3-packages-unfurl-requirements:
   pip.installed:
     - bin_env: /usr/bin/python3
-    - requirements: https://raw.githubusercontent.com/obsidianforensics/unfurl/master/requirements.txt
+    - requirements: https://raw.githubusercontent.com/obsidianforensics/unfurl/main/requirements.txt
     - require:
       - sls: remnux.python3-packages.pip
       - sls: remnux.python3-packages.protobuf


### PR DESCRIPTION
The original pinning of the unfurl branch to master was fixed previously, however the location of the requirements.txt file was not. This will fix the pointer to go from master to main.

Tested and confirmed working.