### PR TITLE
Correct issue with latest version of setuptools and thug

### DIFF
--- a/remnux/python3-packages/setuptools.sls
+++ b/remnux/python3-packages/setuptools.sls
@@ -3,7 +3,7 @@ include:
 
 remnux-python3-packages-setuptools:
   pip.installed:
-    - name: setuptools
+    - name: 'setuptools<66.0.0'
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:


### PR DESCRIPTION
The latest version of setuptools seems to introduce an error where the installation of ssdeep (thug requirement) would result in the following error:  
`pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: '0.23ubuntu1'`

This was introduced in 66.0.0 and is not present in versions under 66. This state change pins the version of setuptools to anything under 66.0.0