### PR TITLE
Prevent future issues with cloning thug

### DIFF
--- a/remnux/python3-packages/thug.sls
+++ b/remnux/python3-packages/thug.sls
@@ -26,8 +26,10 @@ remnux-python3-packages-thug-git:
   git.latest:
     - name: https://github.com/buffer/thug
     - target: /usr/local/src/thug
+    - branch: master
     - force_reset: True
     - force_checkout: True
+    - force_fetch: True
 
 remnux-python3-packages-thug-packages:
   pip.installed:


### PR DESCRIPTION
This should prevent thug from having any future issues when attempting to clone the repo, resolving #226. Added the branch and `force_fetch: True` to avoid the Fast Forward error.