### PR TITLE
Update remaining git states to allow for force_fetch

### DIFF
--- a/remnux/python3-packages/viper-framework.sls
+++ b/remnux/python3-packages/viper-framework.sls
@@ -101,10 +101,13 @@ remnux-python3-packages-viper-directory:
       - user: remnux-user-{{ user }}
 
 remnux-python3-packages-viper-modules-git:
-  git.cloned:
+  git.latest:
     - name: https://github.com/viper-framework/viper-modules.git
     - target: {{ home }}/.viper/modules
     - user: {{ user }}
+    - force_reset: True
+    - force_checkout: True
+    - force_fetch: True
     - require:
       - file: remnux-python3-packages-viper-directory
 

--- a/remnux/tools/automater.sls
+++ b/remnux/tools/automater.sls
@@ -12,11 +12,14 @@ include:
   - remnux.python-packages.certifi
 
 remnux-tools-automater:
-  git.cloned:
+  git.latest:
     - name: https://github.com/1aN0rmus/TekDefense-Automater
     - target: /usr/local/automater
     - user: root
     - branch: master
+    - force_fetch: True
+    - force_reset: True
+    - force_checkout: True
 
 remnux-tools-automater-binary:
   file.managed:

--- a/remnux/tools/captipper.sls
+++ b/remnux/tools/captipper.sls
@@ -17,6 +17,7 @@ remnux-tools-captipper:
     - target: /usr/local/CapTipper
     - force_reset: True
     - force_checkout: True
+    - force_fetch: True
     - user: root
     - require:
       - sls: remnux.packages.python3

--- a/remnux/tools/shellcode2exe-bat.sls
+++ b/remnux/tools/shellcode2exe-bat.sls
@@ -11,11 +11,14 @@ include:
   - remnux.packages.wine
 
 remnux-tools-shellcode2exe-bat:
-  git.cloned:
+  git.latest:
     - name: https://github.com/repnz/shellcode2exe.git
     - target: /usr/local/shellcode2exe-bat
     - user: root
     - branch: master
+    - force_fetch: True
+    - force_reset: True
+    - force_checkout: True
     - require:
       - sls: remnux.packages.wine
 

--- a/remnux/tools/yara-rules.sls
+++ b/remnux/tools/yara-rules.sls
@@ -11,11 +11,14 @@ include:
   - remnux.packages.yara
 
 remnux-tools-yara-rules:
-  git.cloned:
+  git.latest:
     - name: https://github.com/Yara-Rules/rules.git
     - target: /usr/local/yara-rules
     - user: root
     - branch: master
+    - force_fetch: True
+    - force_reset: True
+    - force_checkout: True
     - require:
       - sls: remnux.packages.yara
 


### PR DESCRIPTION
In keeping with the recent update to the Thug state, this PR will set git latest to the remaining git states, and assign the `force_` configurations to ensure that there are no issues with cloning or Fast Forward issues.

I know that Viper isn't in use right now, however I made the change in the off-chance it does get used in the future, then it's ready to go.