### PR TITLE
Update inspircd and its requirements

### DIFF
--- a/remnux/packages/gnutls-bin.sls
+++ b/remnux/packages/gnutls-bin.sls
@@ -1,0 +1,2 @@
+gnutls-bin:
+  pkg.installed

--- a/remnux/packages/inspircd.sls
+++ b/remnux/packages/inspircd.sls
@@ -6,37 +6,53 @@
 # License: GNU General Public License (GPL) v2: https://docs.inspircd.org/license/
 # Notes: 
 
-{%- if grains['oscodename'] == "bionic" %}
 
-remnux-packages-inspircd-source:
-  file.managed:
-    - name: /usr/local/src/inspircd_3.8.1.ubuntu18.04.1_amd64.deb
-    - source: https://github.com/inspircd/inspircd/releases/download/v3.8.1/inspircd_3.8.1.ubuntu18.04.1_amd64.deb
-    - source_hash: sha256=d993a9333395826d1312c940ef72e53c5d67217f481c08c2b00709352bdcae8f
-
-remnux-packages-inspircd-install:
-  pkg.installed:
-    - sources:
-      - inspircd: /usr/local/src/inspircd_3.8.1.ubuntu18.04.1_amd64.deb
-    - watch:
-      - file: remnux-packages-inspircd-source
-
-{%- elif grains['oscodename'] == "focal" %}
-
-remnux-packages-inspircd-source:
-  file.managed:
-    - name: /usr/local/src/inspircd_3.8.1.ubuntu20.04.1_amd64.deb
-    - source: https://github.com/inspircd/inspircd/releases/download/v3.8.1/inspircd_3.8.1.ubuntu20.04.1_amd64.deb
-    - source_hash: sha256=62cdd3dc915135ef4331b384217475ed0a4421198a02398efe1e016877c8c8dd
-
-remnux-packages-inspircd-install:
-  pkg.installed:
-    - sources:
-      - inspircd: /usr/local/src/inspircd_3.8.1.ubuntu20.04.1_amd64.deb
-    - watch:
-      - file: remnux-packages-inspircd-source
-
+{% set version = '3.15.0' %}
+{%- if grains['oscodename'] == "focal" %}
+  {% set os_rel = '20.04.3' %}
+  {% set hash = '2d98e442c4a2a9a59bda10729eb8aac31444f5fedb58fcc65d23d415e03e7c2f' %}
+{% elif grains['oscodename'] == "bionic" %}
+  {% set os_rel = '18.04.3' %}
+  {% set hash = 'b3dec6e276446dbf17dde874433f73bfec1e45a3e601835dab6aeef17c94c380' %}
 {% endif %}
+
+include:
+  - remnux.packages.libpq5
+  - remnux.packages.libre2
+  - remnux.packages.libtre5
+  - remnux.packages.gnutls-bin
+{% if grains['oscodename'] == "bionic" %}
+  - remnux.packages.perl
+  - remnux.packages.libargon2-0
+  - remnux.packages.libmysqlclient20
+  - remnux.packages.libpcre2-8-0
+  - remnux.packages.libio-socket-ssl-perl
+{% endif %}
+
+remnux-packages-inspircd-source:
+  file.managed:
+    - name: /usr/local/src/inspircd_{{ version }}.ubuntu{{ os_rel }}_amd64.deb
+    - source: https://github.com/inspircd/inspircd/releases/download/v{{ version }}/inspircd_{{ version }}.ubuntu{{ os_rel }}_amd64.deb
+    - source_hash: sha256={{ hash }}
+
+remnux-packages-inspircd-install:
+  pkg.installed:
+    - sources:
+      - inspircd: /usr/local/src/inspircd_{{ version }}.ubuntu{{ os_rel }}_amd64.deb
+    - require:
+      - sls: remnux.packages.libpq5
+      - sls: remnux.packages.libre2
+      - sls: remnux.packages.libtre5
+      - sls: remnux.packages.gnutls-bin
+{% if grains['oscodename'] == "bionic" %}
+      - sls: remnux.packages.perl
+      - sls: remnux.packages.libargon2-0
+      - sls: remnux.packages.libmysqlclient20
+      - sls: remnux.packages.libpcre2-8-0
+      - sls: remnux.packages.libio-socket-ssl-perl
+{% endif %}
+    - watch:
+      - file: remnux-packages-inspircd-source
 
 # Runlevel isn't in a Docker container, so check whether it exists before
 # trying to control services

--- a/remnux/packages/libargon2-0.sls
+++ b/remnux/packages/libargon2-0.sls
@@ -1,0 +1,2 @@
+libargon2-0:
+  pkg.installed

--- a/remnux/packages/libio-socket-ssl-perl.sls
+++ b/remnux/packages/libio-socket-ssl-perl.sls
@@ -1,0 +1,2 @@
+libio-socket-ssl-perl:
+  pkg.installed

--- a/remnux/packages/libmysqlclient20.sls
+++ b/remnux/packages/libmysqlclient20.sls
@@ -1,0 +1,2 @@
+libmysqlclient20:
+  pkg.installed

--- a/remnux/packages/libpcre2-8-0.sls
+++ b/remnux/packages/libpcre2-8-0.sls
@@ -1,0 +1,2 @@
+libpcre2-8-0:
+  pkg.installed

--- a/remnux/packages/libpq5.sls
+++ b/remnux/packages/libpq5.sls
@@ -1,0 +1,2 @@
+libpq5:
+  pkg.installed

--- a/remnux/packages/libre2.sls
+++ b/remnux/packages/libre2.sls
@@ -1,0 +1,11 @@
+{% if grains['oscodename'] == "focal" %}
+
+libre2-5:
+  pkg.installed
+
+{% elif grains['oscodename'] == "bionic" %}
+
+libre2-4:
+  pkg.installed
+
+{% endif %}

--- a/remnux/packages/libtre5.sls
+++ b/remnux/packages/libtre5.sls
@@ -1,0 +1,2 @@
+libtre5:
+  pkg.installed


### PR DESCRIPTION
This state not only upgrades inspircd, but adds the additional requirements necessary for this. Currently, when installing the previous version of inspircd in addon mode in a server version (or docker) of Ubuntu, the installation fails and causes several errors due to broken requirements, and apt's inability to install them.