### PR TITLE
Update repos for compat with Jammy and prepare for future APT-KEY Deprecation

### DIFF
--- a/remnux/repos/docker.sls
+++ b/remnux/repos/docker.sls
@@ -1,8 +1,17 @@
-docker:
+remnux-docker-key:
+  file.managed:
+    - name: /usr/share/keyrings/DOCKER-PGP-KEY.asc
+    - source: https://download.docker.com/linux/ubuntu/gpg
+    - skip_verify: True
+    - makedirs: True
+
+remnux-docker-repo:
   pkgrepo.managed:
     - humanname: Docker
-    - name: deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ grains['lsb_distrib_codename'] }} stable
+    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/DOCKER-PGP-KEY.asc] https://download.docker.com/linux/ubuntu {{ grains['lsb_distrib_codename'] }} stable
     - dist: {{ grains['lsb_distrib_codename'] }}
     - file: /etc/apt/sources.list.d/docker.list
-    - key_url: https://download.docker.com/linux/ubuntu/gpg
-    - refresh: true
+    - refresh: True
+    - clean_file: True
+    - require:
+      - file: remnux-docker-key

--- a/remnux/repos/draios.sls
+++ b/remnux/repos/draios.sls
@@ -1,9 +1,15 @@
+remnux-draios-key:
+  file.managed:
+    - name: /usr/share/keyrings/DRAIOS-GPG-KEY.asc
+    - source: salt://remnux/repos/files/DRAIOS-GPG-KEY.asc
+    - skip_verify: True
+    - makedirs: True
+
 draios:
   pkgrepo.managed:
     - humanname: Draios
-    - name: deb http://download.draios.com/stable/deb stable-{{ grains['osarch'] }}/
+    - name: deb [arch={{ grains['osarch'] }} signed-by=/usr/share/keyrings/DRAIOS-GPG-KEY.asc] http://download.draios.com/stable/deb stable-{{ grains['osarch'] }}/
     - file: /etc/apt/sources.list.d/draios.list
-    # Source - https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public
-    - key_url: salt://remnux/repos/files/DRAIOS-GPG-KEY.asc
-    - gpgcheck: 1
     - refresh: true
+    - require:
+      - file: remnux-draios-key

--- a/remnux/repos/gift.sls
+++ b/remnux/repos/gift.sls
@@ -1,7 +1,16 @@
+remnux-gift-key:
+  file.managed:
+    - name: /usr/share/keyrings/GIFT-GPG-KEY.asc
+    - source: salt://remnux/repos/files/GIFT-GPG-KEY.asc
+    - skip_verify: True
+    - makedirs: True
+
 gift-repo:
   pkgrepo.managed:
-    - ppa: gift/stable
-    - refresh: true
-    # Source - https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3ED1EAECE81894B171D7DA5B5E80511B10C598B8
-    - key_url: salt://remnux/repos/files/GIFT-GPG-KEY.asc
-    - gpgcheck: 1
+    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/GIFT-GPG-KEY.asc] http://ppa.launchpad.net/gift/stable/ubuntu {{ grains['lsb_distrib_codename'] }} main
+    - dist: {{ grains['lsb_distrib_codename'] }}
+    - file: /etc/apt/sources.list.d/gift-ubuntu-stable-{{ grains['lsb_distrib_codename'] }}.list
+    - refresh: True
+    - clean_file: True
+    - require:
+      - file: remnux-gift-key

--- a/remnux/repos/inetsim.sls
+++ b/remnux/repos/inetsim.sls
@@ -1,9 +1,16 @@
+remnux-inetsim-key:
+  file.managed:
+    - name: /usr/share/keyrings/INETSIM-GPG-KEY.asc
+    - source: salt://remnux/repos/files/INETSIM-GPG-KEY.asc
+    - skip_verify: True
+    - makedirs: True
+
 inetsim-repo:
   pkgrepo.managed:
     - humanname: InetSim
-    - name: deb http://www.inetsim.org/debian/ binary/
+    - name: deb [signed-by=/usr/share/keyrings/INETSIM-GPG-KEY.asc] http://www.inetsim.org/debian/ binary/
     - file: /etc/apt/sources.list.d/inetsim.list
-    # Source - http://www.inetsim.org/inetsim-archive-signing-key.asc
-    - key_url: salt://remnux/repos/files/INETSIM-GPG-KEY.asc
-    - gpgcheck: 1
-    - refresh: true
+    - refresh: True
+    - clean_file: True
+    - require:
+      - file: remnux-inetsim-key

--- a/remnux/repos/microsoft-vscode.sls
+++ b/remnux/repos/microsoft-vscode.sls
@@ -1,9 +1,17 @@
+remnux-microsoft-vscode-key:
+  file.managed:
+    - name: /usr/share/keyrings/MICROSOFT.asc
+    - source: https://packages.microsoft.com/keys/microsoft.asc
+    - skip_verify: True
+    - makedirs: True
+
 microsoft-vscode:
   pkgrepo.managed:
     - humanname: Microsoft Visual Studio Code
-    - name: deb [arch=amd64] http://packages.microsoft.com/repos/vscode stable main
+    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/MICROSOFT.asc] http://packages.microsoft.com/repos/vscode stable main
     - file: /etc/apt/sources.list.d/vscode.list
-    - key_url: https://packages.microsoft.com/keys/microsoft.asc
-    - refresh: true
+    - refresh: True
+    - clean_file: True
     - require:
       - sls: remnux.repos.nodejs
+      - file: remnux-microsoft-vscode-key

--- a/remnux/repos/microsoft.sls
+++ b/remnux/repos/microsoft.sls
@@ -1,8 +1,17 @@
+remnux-microsoft-key:
+  file.managed:
+    - name: /usr/share/keyrings/MICROSOFT.asc
+    - source: https://packages.microsoft.com/keys/microsoft.asc
+    - skip_verify: True
+    - makedirs: True
+
 microsoft:
   pkgrepo.managed:
     - humanname: Microsoft
-    - name: deb [arch=amd64] https://packages.microsoft.com/ubuntu/{{ grains['lsb_distrib_release'] }}/prod {{ grains['lsb_distrib_codename'] }} main
+    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/MICROSOFT.asc] https://packages.microsoft.com/ubuntu/{{ grains['lsb_distrib_release'] }}/prod {{ grains['lsb_distrib_codename'] }} main
     - dist: {{ grains['lsb_distrib_codename'] }}
     - file: /etc/apt/sources.list.d/microsoft.list
-    - key_url: https://packages.microsoft.com/keys/microsoft.asc
-    - refresh: true
+    - refresh: True
+    - clean_file: True
+    - require:
+      - file: remnux-microsoft-key

--- a/remnux/repos/mono.sls
+++ b/remnux/repos/mono.sls
@@ -3,5 +3,7 @@ mono-repo:
     - humanname: Mono
     - name: deb [arch=amd64] https://download.mono-project.com/repo/ubuntu stable-{{ grains['lsb_distrib_codename'] }} main
     - file: /etc/apt/sources.list.d/mono-official-stable.list
+    - dist: stable-{{ grains['lsb_distrib_codename'] }}
     - key_url: https://download.mono-project.com/repo/xamarin.gpg
-    - refresh: true
+    - refresh: True
+    - clean_file: True

--- a/remnux/repos/nodejs.sls
+++ b/remnux/repos/nodejs.sls
@@ -1,3 +1,9 @@
+remnux-nodejs-key:
+  file.managed:
+    - name: /usr/share/keyrings/NODESOURCE-GPG.KEY
+    - source: http://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    - skip_verify: True
+    - makedirs: True
 
 nodejs-repo-cleanup:
   pkgrepo.absent:
@@ -7,10 +13,10 @@ nodejs-repo-cleanup:
 nodejs-repo:
   pkgrepo.managed:
     - humanname: nodejs
-    - name: deb http://deb.nodesource.com/node_14.x {{ grains['lsb_distrib_codename'] }} main
+    - name: deb [signed-by=/usr/share/keyrings/NODESOURCE-GPG.KEY] http://deb.nodesource.com/node_14.x {{ grains['lsb_distrib_codename'] }} main
     - file: /etc/apt/sources.list.d/nodesource.list
-    - key_url: http://deb.nodesource.com/gpgkey/nodesource.gpg.key
-    - gpgcheck: 1
-    - refresh: true
+    - refresh: True
+    - clean_file: True
     - require:
       - pkgrepo: nodejs-repo-cleanup
+      - file: remnux-nodejs-key

--- a/remnux/repos/remnux.sls
+++ b/remnux/repos/remnux.sls
@@ -1,7 +1,15 @@
+remnux-repo-key:
+  file.managed:
+    - name: /usr/share/keyrings/REMNUX-GPG-KEY.asc
+    - source: salt://remnux/repos/files/REMNUX-GPG-KEY.asc
+    - skip_verify: True
+    - makedirs: True
+
 remnux-repo:
   pkgrepo.managed:
-    - ppa: remnux/stable
-    - refresh: true
-    # Source - https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xbff45016788de115
-    - key_url: salt://remnux/repos/files/REMNUX-GPG-KEY.asc
-    - gpgcheck: 1
+    - name: deb [signed-by=/usr/share/keyrings/REMNUX-GPG-KEY.asc] http://ppa.launchpad.net/remnux/stable/ubuntu {{ grains['lsb_distrib_codename'] }} main
+    - file: /etc/apt/sources.list.d/remnux-stable-{{ grains['lsb_distrib_codename'] }}.list
+    - refresh: True
+    - clean_file: True
+    - require:
+      - file: remnux-repo-key

--- a/remnux/repos/saltstack.sls
+++ b/remnux/repos/saltstack.sls
@@ -1,16 +1,27 @@
+remnux-saltstack-key:
+  file.managed:
+    - name: /usr/share/keyrings/salt-archive-keyring.gpg
+    - source: https://repo.saltproject.io/py3/ubuntu/{{ grains['lsb_distrib_release'] }}/{{ grains['osarch'] }}/3004/salt-archive-keyring.gpg
+    - skip_verify: True
+    - makedirs: True
 
 saltstack-repo-cleanup:
   pkgrepo.absent:
     - name: deb [arch={{ grains['osarch'] }}] https://repo.saltproject.io/py3/ubuntu/{{ grains['lsb_distrib_release'] }}/{{ grains['osarch'] }}/3001 focal main
     - refresh: true
 
+saltstack-repo-file-absent:
+  file.absent:
+    - name: /etc/apt/sources.list.d/saltstack.list
+
 saltstack-repo:
   pkgrepo.managed:
     - humanname: saltstack
-    - name: deb [arch={{ grains['osarch'] }}] https://repo.saltproject.io/py3/ubuntu/{{ grains['lsb_distrib_release'] }}/{{ grains['osarch'] }}/3004 focal main
+    - name: deb [arch={{ grains['osarch'] }} signed-by=/usr/share/keyrings/salt-archive-keyring.gpg] https://repo.saltproject.io/py3/ubuntu/{{ grains['lsb_distrib_release'] }}/{{ grains['osarch'] }}/3004 focal main
     - file: /etc/apt/sources.list.d/saltstack.list
-    - key_url: https://repo.saltproject.io/py3/ubuntu/{{ grains['lsb_distrib_release'] }}/{{ grains['osarch'] }}/3004/salt-archive-keyring.gpg
-    - gpgcheck: 1
-    - refresh: true
+    - refresh: True
+    - clean_file: True
     - require:
       - pkgrepo: saltstack-repo-cleanup
+      - file: saltstack-repo-file-absent
+      - file: remnux-saltstack-key

--- a/remnux/repos/sift.sls
+++ b/remnux/repos/sift.sls
@@ -14,10 +14,18 @@ sift-stable:
 
 {%- endif %}
 
+sift-repo-key:
+  file.managed:
+    - name: /usr/share/keyrings/SIFT-GPG-KEY.asc
+    - source: salt://remnux/repos/files/SIFT-GPG-KEY.asc
+    - skip_verify: True
+    - makedirs: True
+
 sift-repo:
   pkgrepo.managed:
-    - ppa: sift/{{ version }}
-    - refresh: true
-    # Source - https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb2a668dd0744bec3
-    - key_url: salt://remnux/repos/files/SIFT-GPG-KEY.asc
-    - gpgcheck: 1
+    - name: deb [signed-by=/usr/share/keyrings/SIFT-GPG-KEY.asc] http://ppa.launchpad.net/sift/stable/ubuntu {{ grains['lsb_distrib_codename'] }} main
+    - file: /etc/apt/sources.list.d/sift-stable-{{ grains['lsb_distrib_codename'] }}.list
+    - refresh: True
+    - clean_file: True
+    - require:
+      - file: sift-repo-key


### PR DESCRIPTION
The APT-KEY function within Ubuntu will be end of life after Jammy, and SaltStack will no longer support it. This feature is used by the "key_url", "gpgcheck" and "ppa" portions of the SaltStack pkgrepo.managed module.

To prepare for the upcoming deprecation, and still maintain support for Focal, I've updated most of the states to accept the new method, which is adding the `signed-by` portion of the name, and downloading the keys to the `/usr/share/keyrings` folder. Unfortunately, for some reason I couldn't get this to work with Mono, as I kept getting a "NO_PUBKEY" error when using the Xamarin.gpg key, so it is not updated.

I also left OpenJDK and Wireshark-Dev off the list until I can confirm the correct keys and the best location to source them from.

This should also fix the issue seen by @Cloud-Hacking in [Issue 119](https://github.com/REMnux/remnux-cli/issues/119).