### PR TITLE
Update Draios repo and linux-headers for sysdig

### DIFF
--- a/remnux/packages/linux-headers.sls
+++ b/remnux/packages/linux-headers.sls
@@ -1,3 +1,3 @@
 remnux-linux-headers:
   pkg.installed:
-      - name: linux-headers-generic
+      - name: linux-headers-{{ grains['kernelrelease'] }}

--- a/remnux/repos/draios.sls
+++ b/remnux/repos/draios.sls
@@ -1,14 +1,14 @@
 remnux-draios-key:
   file.managed:
     - name: /usr/share/keyrings/DRAIOS-GPG-KEY.asc
-    - source: salt://remnux/repos/files/DRAIOS-GPG-KEY.asc
+    - source: https://download.sysdig.com/DRAIOS-GPG-KEY.public
     - skip_verify: True
     - makedirs: True
 
 draios:
   pkgrepo.managed:
     - humanname: Draios
-    - name: deb [arch={{ grains['osarch'] }} signed-by=/usr/share/keyrings/DRAIOS-GPG-KEY.asc] http://download.draios.com/stable/deb stable-{{ grains['osarch'] }}/
+    - name: deb [arch={{ grains['osarch'] }} signed-by=/usr/share/keyrings/DRAIOS-GPG-KEY.asc] https://download.sysdig.com/stable/deb stable-{{ grains['osarch'] }}/
     - file: /etc/apt/sources.list.d/draios.list
     - refresh: true
     - require:


### PR DESCRIPTION
Draios repo signing key location has changed recently, so this PR updates the source of the key, and the configuration of the .list file.
Additionally, since the linux headers are required for sysdig, and should be specific to the existing kernel, I've modified the linux-headers state to get headers for the specific kernel.