### PR TITLE
Add and restrict python3 cryptography to prevent issues with latest version

### DIFF
--- a/remnux/python3-packages/cryptography.sls
+++ b/remnux/python3-packages/cryptography.sls
@@ -1,0 +1,10 @@
+include:
+  - remnux.packages.python3-pip
+
+python3-cryptography:
+  pip.installed:
+    - name: cryptography==39.0.2
+    - bin_env: /usr/bin/python3
+    - upgrade: False
+    - require:
+      - sls: remnux.packages.python3-pip

--- a/remnux/python3-packages/init.sls
+++ b/remnux/python3-packages/init.sls
@@ -1,5 +1,6 @@
 include:
   - remnux.python3-packages.pip
+  - remnux.python3-packages.cryptography
   - remnux.python3-packages.androguard
   - remnux.python3-packages.docker-compose
   - remnux.python3-packages.ioc-parser
@@ -55,6 +56,7 @@ remnux-python3-packages:
   test.nop:
     - require:
       - sls: remnux.python3-packages.pip
+      - sls: remnux.python3-packages.cryptography
       - sls: remnux.python3-packages.androguard
       - sls: remnux.python3-packages.docker-compose
       - sls: remnux.python3-packages.ioc-parser


### PR DESCRIPTION
The latest version of Python 3's cryptography module has some breaking changes which, when upgraded to 40+, cause errors with various applications and states. To alleviate this issue, I'm adding the cryptography state to python3-packages, pinning it to 39.02, and calling it right after pip to ensure that it's in the system at its desired version prior to the installation of requirements from  other tools.

This will resolve [Issue 119](https://github.com/REMnux/remnux-cli/issues/119).