### PR TITLE
Correct error in linux headers for WSL compatibility

### DIFF
--- a/remnux/packages/linux-headers.sls
+++ b/remnux/packages/linux-headers.sls
@@ -1,3 +1,14 @@
+{% set kernel = grains['kernelrelease'] %}
+
+{% if "-WSL" in kernel %}
+
+linux-headers-generic:
+  pkg.installed
+
+{% else %}
+
 remnux-linux-headers:
   pkg.installed:
-      - name: linux-headers-{{ grains['kernelrelease'] }}
+      - name: linux-headers-{{ kernel }}
+
+{% endif %}


### PR DESCRIPTION
My most recent PR for the linux headers didn't take into account WSL, which returns its own kernel release information for WSL:
```yaml
local:
    5.10.16.3-microsoft-standard-WSL2
```
Of course, this kernel is not specifically available, so I've reverted the state to linux-headers-generic for WSL installations, and kernel specific headers for other Ubuntu environs.