### PR TITLE
Fixed an issue with the linux-headers

### DIFF
--- a/remnux/packages/sysdig.sls
+++ b/remnux/packages/sysdig.sls
@@ -15,4 +15,4 @@ remnux-sysdig:
     - name: sysdig
     - require:
       - pkgrepo: draios
-      - pkg: remnux-linux-headers
+      - sls: remnux.packages.linux-headers


### PR DESCRIPTION
During my recent changes to the linux-headers, I didn't notice that the sysdig state pointed specifically at the title of the pkg, and not the state itself. This is important when determining the Jinja if statement.