### PR TITLE
Add clean_file to draios

### DIFF
--- a/remnux/repos/draios.sls
+++ b/remnux/repos/draios.sls
@@ -11,5 +11,6 @@ draios:
     - name: deb [arch={{ grains['osarch'] }} signed-by=/usr/share/keyrings/DRAIOS-GPG-KEY.asc] https://download.sysdig.com/stable/deb stable-{{ grains['osarch'] }}/
     - file: /etc/apt/sources.list.d/draios.list
     - refresh: true
+    - clean_file: true
     - require:
       - file: remnux-draios-key


### PR DESCRIPTION
The draios repo state is missing the "clean_file" option, which when missing causes the .list file to become overrun with multiple repo entries, resulting in a "does not have a Release" error as seen in [Issue 126](https://github.com/REMnux/remnux-cli/issues/126).

After running this test a few times within the same environment, the `clean_file` option seems to fix this issue permanently.