### PR TITLE
Fix for droidlysis, dc3-mwcp, unfurl, importlib

### DIFF
--- a/remnux/addon.sls
+++ b/remnux/addon.sls
@@ -13,6 +13,7 @@ include:
   - remnux.tools
   - remnux.node-packages
   - remnux.perl-packages
+  - remnux.python3-packages.importlib-metadata
 
 remnux-addon-version-file:
   file.managed:
@@ -31,3 +32,4 @@ remnux-addon-version-file:
       - sls: remnux.tools
       - sls: remnux.node-packages
       - sls: remnux.perl-packages
+      - sls: remnux.python3-packages.importlib-metadata

--- a/remnux/python3-packages/dc3-mwcp.sls
+++ b/remnux/python3-packages/dc3-mwcp.sls
@@ -13,6 +13,7 @@ remnux-dc3-mwcp-install:
   pip.installed:
     - name: mwcp
     - bin_env: /usr/bin/python3
+    - ignore_installed: True
     - upgrade: True
     - require:
       - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/droidlysis.sls
+++ b/remnux/python3-packages/droidlysis.sls
@@ -13,6 +13,7 @@
 
 include:
   - remnux.python3-packages.pip
+  - remnux.python3-packages.typing-extensions
   - remnux.tools.apktool
   - remnux.packages.baksmali
   - remnux.packages.dex2jar
@@ -31,12 +32,13 @@ remnux-python-packages-droidlysis:
       - sls: remnux.python3-packages.pip
       - sls: remnux.packages.procyon-decompiler
       - sls: remnux.packages.unzip
+      - sls: remnux.python3-packages.typing-extensions
 
 remnux-python-packages-droidlysis-droidconfig-set1:
   file.replace:
-    - name: /usr/local/lib/{{ python3_version }}/dist-packages/droidconfig.py
-    - pattern: '^APKTOOL_JAR.*$'
-    - repl: 'APKTOOL_JAR = os.path.join(os.path.expanduser("/usr/local/apktool"), "apktool_2.4.1.jar")'
+    - name: /usr/local/lib/{{ python3_version }}/dist-packages/conf/general.conf
+    - pattern: '^apktool =.*$'
+    - repl: 'apktool = /usr/local/apktool/apktool_2.7.0.jar'
     - prepend_if_not_found: False
     - count: 1
     - require:
@@ -44,9 +46,9 @@ remnux-python-packages-droidlysis-droidconfig-set1:
 
 remnux-python-packages-droidlysis-droidconfig-set2:
   file.replace:
-    - name: /usr/local/lib/{{ python3_version }}/dist-packages/droidconfig.py
-    - pattern: '^BAKSMALI_JAR.*$'
-    - repl: 'BAKSMALI_JAR = os.path.join(os.path.expanduser("/opt/baksmali"), "baksmali-2.4.0.jar")'
+    - name: /usr/local/lib/{{ python3_version }}/dist-packages/conf/general.conf
+    - pattern: '^baksmali =.*$'
+    - repl: 'baksmali = /opt/baksmali/baksmali-2.4.0.jar'
     - prepend_if_not_found: False
     - count: 1
     - require:
@@ -54,9 +56,9 @@ remnux-python-packages-droidlysis-droidconfig-set2:
 
 remnux-python-packages-droidlysis-droidconfig-set3:
   file.replace:
-    - name: /usr/local/lib/{{ python3_version }}/dist-packages/droidconfig.py
-    - pattern: '^DEX2JAR_CMD.*$'
-    - repl: 'DEX2JAR_CMD = os.path.join(os.path.expanduser("/usr/bin"), "d2j-dex2jar")'
+    - name: /usr/local/lib/{{ python3_version }}/dist-packages/conf/general.conf
+    - pattern: '^dex2jar =.*$'
+    - repl: 'dex2jar = /usr/bin/d2j-dex2jar'
     - prepend_if_not_found: False
     - count: 1
     - require:
@@ -64,9 +66,9 @@ remnux-python-packages-droidlysis-droidconfig-set3:
 
 remnux-python-packages-droidlysis-droidconfig-set4:
   file.replace:
-    - name: /usr/local/lib/{{ python3_version }}/dist-packages/droidconfig.py
-    - pattern: '^PROCYON_JAR.*$'
-    - repl: 'PROCYON_JAR = os.path.join(os.path.expanduser("/usr/share/java"), "procyon-decompiler-0.5.32.jar")'
+    - name: /usr/local/lib/{{ python3_version }}/dist-packages/conf/general.conf
+    - pattern: '^procyon =.*$'
+    - repl: 'procyon = /usr/share/java/procyon-decompiler-0.5.32.jar'
     - prepend_if_not_found: False
     - count: 1
     - require:

--- a/remnux/python3-packages/importlib-metadata.sls
+++ b/remnux/python3-packages/importlib-metadata.sls
@@ -1,0 +1,9 @@
+include:
+  - remnux.python3-packages.pip
+
+importlib-metadata<5.0.0:
+  pip.installed:
+    - bin_env: /usr/bin/python3
+    - upgrade: False
+    - require:
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/name-that-hash.sls
+++ b/remnux/python3-packages/name-that-hash.sls
@@ -11,7 +11,7 @@ include:
 
 remnux-python3-packages-name-that-hash-install:
   pip.installed:
-    - name: name-that-hash==1.1.0
+    - name: name-that-hash
     - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/typing-extensions.sls
+++ b/remnux/python3-packages/typing-extensions.sls
@@ -1,0 +1,17 @@
+# Name: typing-extensions
+# Website: https://github.com/python/typing_extensions
+# Description: Typing Extensions and hints for Python
+# Category: 
+# Author: Python.org
+# License: Python Software Foundation License v2 (https://github.com/python/typing_extensions/blob/main/LICENSE)
+# Notes: 
+
+include:
+  - remnux.python3-packages.pip
+
+typing-extensions>=4.5.0:
+  pip.installed:
+    - bin_env: /usr/bin/python3
+    - upgrade: True
+    - require:
+      - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/unfurl.sls
+++ b/remnux/python3-packages/unfurl.sls
@@ -15,6 +15,7 @@ remnux-python3-packages-unfurl-requirements:
   pip.installed:
     - bin_env: /usr/bin/python3
     - requirements: https://raw.githubusercontent.com/obsidianforensics/unfurl/main/requirements.txt
+    - ignore_installed: True
     - require:
       - sls: remnux.python3-packages.pip
       - sls: remnux.python3-packages.protobuf
@@ -23,6 +24,7 @@ remnux-python3-packages-unfurl:
   pip.installed:
     - bin_env: /usr/bin/python3
     - name: git+https://github.com/obsidianforensics/unfurl.git
+    - ignore_installed: True
     - require:
       - sls: remnux.python3-packages.pip
       - sls: remnux.packages.git

--- a/remnux/tools/apktool.sls
+++ b/remnux/tools/apktool.sls
@@ -6,6 +6,9 @@
 # License: Apache License 2.0: https://github.com/iBotPeaches/Apktool/blob/master/LICENSE
 # Notes: 
 
+{% set hash = 'c11b5eb518d9ac2ab18e959cbe087499079072b04d567cdcae5ceb447f9a7e7d' %}
+{% set version = '2.7.0' %}
+
 include:
   - remnux.packages.default-jre
 
@@ -19,9 +22,9 @@ remnux-tools-apktool-directory:
 
 remnux-tools-apktool-source:
   file.managed:
-    - name: /usr/local/apktool/apktool_2.4.1.jar
-    - source: https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_2.4.1.jar
-    - source_hash: sha256=bdeb66211d1dc1c71f138003ce35f6d0cd19af6f8de7ffbdd5b118d02d825a52
+    - name: /usr/local/apktool/apktool_{{ version }}.jar
+    - source: https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_{{ version }}.jar
+    - source_hash: sha256={{ hash }}
     - mode: 755
     - watch:
       - file: remnux-tools-apktool-directory
@@ -36,4 +39,4 @@ remnux-tools-apktool-wrapper:
       - file: remnux-tools-apktool-source
     - contents:
       - '#!/bin/bash'
-      - java -jar /usr/local/apktool/apktool_2.4.1.jar ${*}
+      - java -jar /usr/local/apktool/apktool_{{ version }}.jar ${*}


### PR DESCRIPTION
This PR wasn't intended to be a large one, but ended up this way.

This resolves:
- The `Unfurl` issue (caused by blinker not installing) [Issue 132](https://github.com/REMnux/remnux-cli/issues/132), [Issue 131](https://github.com/REMnux/remnux-cli/issues/131), and [Issue 130](https://github.com/REMnux/remnux-cli/issues/130), as well as [240](https://github.com/REMnux/salt-states/issues/240
- The droidlysis execution issue - config file updated in `/usr/local/lib/python3/dist-packages/conf/general.conf` and other issues which surrounded the execution [239](https://github.com/REMnux/salt-states/issues/239)
- The ever persistent importlib-metadata issue.
