### PR TITLE
Fix pip and setuptools issues with METADATA

### DIFF
--- a/remnux/python3-packages/malchive.sls
+++ b/remnux/python3-packages/malchive.sls
@@ -9,6 +9,7 @@
 include:
   - remnux.python3-packages.pip
   - remnux.packages.git
+  - remnux.packages.libsqlite3-dev
   - remnux.python3-packages.cffi
 
 remnux-python3-packages-malchive:
@@ -18,4 +19,5 @@ remnux-python3-packages-malchive:
     - require:
       - sls: remnux.python3-packages.pip
       - sls: remnux.packages.git
+      - sls: remnux.packages.libsqlite3-dev
       - sls: remnux.python3-packages.cffi

--- a/remnux/python3-packages/pip.sls
+++ b/remnux/python3-packages/pip.sls
@@ -3,7 +3,7 @@ include:
 
 remnux-python3-packages-pip3:
   pip.installed:
-    - name: pip>=21.2.4
+    - name: pip>=23.2.1
     - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.packages.python3-pip


### PR DESCRIPTION
This PR incorporates (unintentionally) two fixes for issues related to python3 tools. The first pins the pip3 binary at a current and most recently stable version of 23.2.1, which will resolve Issue #247.
The second fix is for the malchive Python3 package which, when installed separately without libsqlite3-dev will fail. Added this requirement to the state.