### PR TITLE
Add Dissect to REMnux

### DIFF
--- a/remnux/config/dissect-venv.sh
+++ b/remnux/config/dissect-venv.sh
@@ -1,0 +1,13 @@
+dissect() {
+    . /opt/dissect/bin/activate
+
+    local dissect_target_dir=$(dirname $(python3 -c "import dissect.target; print(dissect.target.__file__)"))
+    local autocompletion_dir="${dissect_target_dir}/data/autocompletion"
+
+    if [[ -d "$autocompletion_dir" ]]; then
+        for file in $autocompletion_dir/*;
+        do
+            source $file
+        done
+    fi
+}

--- a/remnux/packages/libfuse2.sls
+++ b/remnux/packages/libfuse2.sls
@@ -1,0 +1,2 @@
+libfuse2:
+  pkg.installed

--- a/remnux/packages/python39.sls
+++ b/remnux/packages/python39.sls
@@ -1,0 +1,2 @@
+python3.9:
+  pkg.installed

--- a/remnux/python3-packages/dissect.sls
+++ b/remnux/python3-packages/dissect.sls
@@ -1,0 +1,47 @@
+# Name: dissect
+# Website: https://github.com/fox-it/dissect
+# Description: Dissect is a digital forensics & incident response framework and
+# toolset that allows you to quickly access and analyse forensic artefacts from
+# various disk and file formats, developed by Fox-IT (part of NCC Group).
+# Category: Perform system analysis
+# Author: Dissect Team: dissect@fox-it.com
+# License: Affero General Public License v3: https://github.com/fox-it/dissect/blob/main/LICENSE
+# Notes: target-query, target-shell, target-dump, target-info, target-reg, target-dd, target-mount
+
+include:
+  - remnux.python3-packages.pip
+  - remnux.packages.python3-virtualenv
+  - remnux.packages.python39
+  - remnux.packages.libfuse2
+
+# Create a virtualenv for dissect
+remnux-python3-packages-dissect-virtualenv:
+  virtualenv.managed:
+    - name: /opt/dissect
+    - python: /usr/bin/python3.9
+    - pip_pkgs:
+      - pip
+      - setuptools
+      - wheel
+    - require:
+      - sls: remnux.packages.python39
+      - sls: remnux.python3-packages.pip
+      - sls: remnux.packages.python3-virtualenv
+
+# Install dissect inside the virtualenv
+remnux-python3-packages-dissect-install:
+  pip.installed:
+    - name: dissect
+    - bin_env: /opt/dissect/bin/python3
+    - upgrade: True
+    - user: root
+    - require:
+      - virtualenv: remnux-python3-packages-dissect-virtualenv
+
+remnux-python3-packages-dissect-venv-shortcut:
+  file.managed:
+    - name: /etc/profile.d/dissect-venv.sh
+    - source: salt://remnux/config/dissect-venv.sh
+    - makedirs: False
+    - require:
+      - pip: remnux-python3-packages-dissect-install

--- a/remnux/python3-packages/dissect.sls
+++ b/remnux/python3-packages/dissect.sls
@@ -8,23 +8,31 @@
 # License: Affero General Public License v3: https://github.com/fox-it/dissect/blob/main/LICENSE
 # Notes: target-query, target-shell, target-dump, target-info, target-reg, target-dd, target-mount
 
+{%- if grains['oscodename'] == "focal" %}
+  {%- set python3_version="python3.9" %}
+  {%- set python3_dependency="python39" %} 
+{%- else %}
+  {%- set python3_version="python3" %}
+  {%- set python3_dependency="python3" %} 
+{% endif %}
+
 include:
   - remnux.python3-packages.pip
   - remnux.packages.python3-virtualenv
-  - remnux.packages.python39
+  - remnux.packages.{{ python3_dependency }}
   - remnux.packages.libfuse2
 
 # Create a virtualenv for dissect
 remnux-python3-packages-dissect-virtualenv:
   virtualenv.managed:
     - name: /opt/dissect
-    - python: /usr/bin/python3.9
+    - python: /usr/bin/{{ python3_version }}
     - pip_pkgs:
       - pip
       - setuptools
       - wheel
     - require:
-      - sls: remnux.packages.python39
+      - sls: remnux.packages.{{ python3_dependency }}
       - sls: remnux.python3-packages.pip
       - sls: remnux.packages.python3-virtualenv
 


### PR DESCRIPTION
This state file adds the `dissect` suite.

This commit adds:
  - install `python3.9` as its the minimum version that dissect supports. That does mean it does not function on `bionic`.
  - a virtual environment with `dissect` so there are no changes to the system packages.
  - an utility script to `/etc/profile` so you can execute `dissect` in your bash session. This loads both the virtual environment and the auto-completion scripts.
  - install `libfuse2` which is required for `target-mount`.
