### PR TITLE
Remove the Py2 version of peepdf in favor of a new Py3 version

### DIFF
--- a/remnux/python-packages/peepdf.sls
+++ b/remnux/python-packages/peepdf.sls
@@ -4,24 +4,15 @@
 # Category: Analyze Documents: PDF
 # Author: Jose Miguel Esparza
 # License: GNU General Public License (GPL) v3: https://github.com/jesparza/peepdf/blob/master/COPYING
-# Notes: 
+# Notes: This state removes the python2 version of peepdf
 
 include:
   - remnux.packages.python2-pip
-  - remnux.packages.libemu
-  - remnux.packages.libjpeg8-dev
-  - remnux.packages.zlib1g-dev
-  - remnux.packages.git
   - remnux.packages.python3-pip
 
-remnux-tools-peepdf-source:
-  pip.installed:
-    - name: git+https://github.com/digitalsleuth/peepdf.git
+remnux-tools-peepdf-remove:
+  pip.removed:
+    - name: peepdf
     - bin_env: /usr/bin/python2
-    - upgrade: True
     - require:
       - sls: remnux.packages.python2-pip
-      - sls: remnux.packages.libemu
-      - sls: remnux.packages.libjpeg8-dev
-      - sls: remnux.packages.zlib1g-dev
-      - sls: remnux.packages.git

--- a/remnux/python3-packages/init.sls
+++ b/remnux/python3-packages/init.sls
@@ -52,6 +52,7 @@ include:
   - remnux.python3-packages.dnfile
   - remnux.python3-packages.dotnetfile
   - remnux.python3-packages.debloat
+  - remnux.python3-packages.peepdf-3
 
 remnux-python3-packages:
   test.nop:
@@ -109,3 +110,4 @@ remnux-python3-packages:
       - sls: remnux.python3-packages.dnfile
       - sls: remnux.python3-packages.dotnetfile
       - sls: remnux.python3-packages.debloat
+      - sls: remnux.python3-packages.peepdf-3

--- a/remnux/python3-packages/peepdf-3.sls
+++ b/remnux/python3-packages/peepdf-3.sls
@@ -1,0 +1,28 @@
+# Name: peepdf
+# Website: https://eternal-todo.com/tools/peepdf-pdf-analysis-tool
+# Description: Examine elements of the PDF file.
+# Category: Analyze Documents: PDF
+# Author: Jose Miguel Esparza and Corey Forman
+# License: GNU General Public License (GPL) v3: https://github.com/digitalsleuth/peepdf-3/blob/main/COPYING
+# Notes:
+
+include:
+  - remnux.packages.python3-pip
+  - remnux.packages.libemu
+  - remnux.packages.libjpeg8-dev
+  - remnux.packages.zlib1g-dev
+  - remnux.packages.git
+  - remnux.python3-packages.stpyv8
+
+remnux-tools-peepdf-3-source:
+  pip.installed:
+    - name: git+https://github.com/digitalsleuth/peepdf-3.git
+    - bin_env: /usr/bin/python3
+    - upgrade: True
+    - require:
+      - sls: remnux.packages.python3-pip
+      - sls: remnux.packages.libemu
+      - sls: remnux.packages.libjpeg8-dev
+      - sls: remnux.packages.zlib1g-dev
+      - sls: remnux.packages.git
+      - sls: remnux.python3-packages.stpyv8


### PR DESCRIPTION
This PR removes the Py2 version of peepdf and installs the new Py3 version, with PyV8 support.