### PR TITLE
Set force_reinstall on pip, setuptools, wheel

### DIFF
--- a/remnux/python3-packages/pip.sls
+++ b/remnux/python3-packages/pip.sls
@@ -5,5 +5,7 @@ remnux-python3-packages-pip3:
   pip.installed:
     - name: pip>=23.2.1
     - bin_env: /usr/bin/python3
+    - upgrade: True
+    - force_reinstall: True
     - require:
       - sls: remnux.packages.python3-pip

--- a/remnux/python3-packages/setuptools.sls
+++ b/remnux/python3-packages/setuptools.sls
@@ -6,5 +6,6 @@ remnux-python3-packages-setuptools:
     - name: 'setuptools>68.0.0'
     - bin_env: /usr/bin/python3
     - upgrade: True
+    - force_reinstall: True
     - require:
       - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/wheel.sls
+++ b/remnux/python3-packages/wheel.sls
@@ -3,8 +3,9 @@ include:
 
 remnux-python3-packages-wheel:
   pip.installed:
-    - name: wheel
+    - name: wheel>=0.41.2
     - bin_env: /usr/bin/python3
     - upgrade: True
+    - force_reinstall: True
     - require:
       - sls: remnux.python3-packages.pip


### PR DESCRIPTION
To address (rather re-address) the issues with pip, setuptools, and wheel, this will force those tools to be reinstalled at the required, currently known-good versions to fix the METADATA/RECORD issues.