### PR TITLE
Modifications to resolve recent python repos

### DIFF
--- a/remnux/addon.sls
+++ b/remnux/addon.sls
@@ -13,7 +13,7 @@ include:
   - remnux.tools
   - remnux.node-packages
   - remnux.perl-packages
-  - remnux.python3-packages.importlib-metadata
+  - remnux.tools.remnux-cli
 
 remnux-addon-version-file:
   file.managed:
@@ -32,4 +32,4 @@ remnux-addon-version-file:
       - sls: remnux.tools
       - sls: remnux.node-packages
       - sls: remnux.perl-packages
-      - sls: remnux.python3-packages.importlib-metadata
+      - sls: remnux.tools.remnux-cli

--- a/remnux/python-packages/volatility.sls
+++ b/remnux/python-packages/volatility.sls
@@ -31,7 +31,8 @@ include:
 # openpyxl is needed for the timeliner plugin
 remnux-python-packages-volatility:
   pip.installed:
-    - name: git+https://github.com/volatilityfoundation/volatility.git@master
+    - name: git+https://github.com/volatilityfoundation/volatility.git
+    - branch: master
     - bin_env: /usr/bin/python2
     - upgrade: True
     - require:

--- a/remnux/python3-packages/init.sls
+++ b/remnux/python3-packages/init.sls
@@ -1,5 +1,8 @@
 include:
   - remnux.python3-packages.pip
+  - remnux.python3-packages.setuptools
+  - remnux.python3-packages.wheel
+  - remnux.python3-packages.requests
   - remnux.python3-packages.cryptography
   - remnux.python3-packages.androguard
   - remnux.python3-packages.docker-compose
@@ -38,8 +41,6 @@ include:
   - remnux.python3-packages.msoffcrypto-tool
   - remnux.python3-packages.qiling
   - remnux.python3-packages.pe-tree
-  - remnux.python3-packages.wheel
-  - remnux.python3-packages.setuptools
   - remnux.python3-packages.hachoir
   - remnux.python3-packages.msg-extractor
   - remnux.python3-packages.name-that-hash
@@ -58,6 +59,9 @@ remnux-python3-packages:
   test.nop:
     - require:
       - sls: remnux.python3-packages.pip
+      - sls: remnux.python3-packages.setuptools
+      - sls: remnux.python3-packages.wheel
+      - sls: remnux.python3-packages.requests
       - sls: remnux.python3-packages.cryptography
       - sls: remnux.python3-packages.androguard
       - sls: remnux.python3-packages.docker-compose
@@ -96,8 +100,6 @@ remnux-python3-packages:
       - sls: remnux.python3-packages.msoffcrypto-tool
       - sls: remnux.python3-packages.qiling
       - sls: remnux.python3-packages.pe-tree
-      - sls: remnux.python3-packages.wheel
-      - sls: remnux.python3-packages.setuptools
       - sls: remnux.python3-packages.hachoir
       - sls: remnux.python3-packages.msg-extractor
       - sls: remnux.python3-packages.name-that-hash

--- a/remnux/python3-packages/malchive.sls
+++ b/remnux/python3-packages/malchive.sls
@@ -15,7 +15,8 @@ include:
 remnux-python3-packages-malchive:
   pip.installed:
     - bin_env: /usr/bin/python3
-    - name: git+https://github.com/MITRECND/malchive.git@main
+    - name: git+https://github.com/MITRECND/malchive.git
+    - branch: main
     - require:
       - sls: remnux.python3-packages.pip
       - sls: remnux.packages.git

--- a/remnux/python3-packages/pip.sls
+++ b/remnux/python3-packages/pip.sls
@@ -3,9 +3,9 @@ include:
 
 remnux-python3-packages-pip3:
   pip.installed:
-    - name: pip>=23.2.1
+    - name: pip>=23.1.2
     - bin_env: /usr/bin/python3
-    - upgrade: True
+    - upgrade: False
     - force_reinstall: True
     - require:
       - sls: remnux.packages.python3-pip

--- a/remnux/python3-packages/requests.sls
+++ b/remnux/python3-packages/requests.sls
@@ -1,9 +1,9 @@
 include:
   - remnux.python3-packages.pip
 
-remnux-python3-packages-setuptools:
+remnux-python3-packages-requests:
   pip.installed:
-    - name: setuptools==67.7.2
+    - name: requests==2.31.0
     - bin_env: /usr/bin/python3
     - upgrade: False
     - force_reinstall: True

--- a/remnux/python3-packages/speakeasy.sls
+++ b/remnux/python3-packages/speakeasy.sls
@@ -20,7 +20,8 @@ remnux-python3-packages-speakeasy-requirements:
 remnux-python3-packages-speakeasy:
   pip.installed:
     - bin_env: /usr/bin/python3
-    - name: git+https://github.com/mandiant/speakeasy.git@master
+    - name: git+https://github.com/mandiant/speakeasy.git
+    - branch: master
     - upgrade: True
     - require:
       - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/wheel.sls
+++ b/remnux/python3-packages/wheel.sls
@@ -3,9 +3,9 @@ include:
 
 remnux-python3-packages-wheel:
   pip.installed:
-    - name: wheel>=0.41.2
+    - name: wheel==0.38.4
     - bin_env: /usr/bin/python3
-    - upgrade: True
+    - upgrade: False
     - force_reinstall: True
     - require:
       - sls: remnux.python3-packages.pip

--- a/remnux/repos/gift.sls
+++ b/remnux/repos/gift.sls
@@ -7,7 +7,7 @@ remnux-gift-key:
 
 gift-repo:
   pkgrepo.managed:
-    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/GIFT-GPG-KEY.asc] http://ppa.launchpad.net/gift/stable/ubuntu {{ grains['lsb_distrib_codename'] }} main
+    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/GIFT-GPG-KEY.asc] https://ppa.launchpadcontent.net/gift/stable/ubuntu {{ grains['lsb_distrib_codename'] }} main
     - dist: {{ grains['lsb_distrib_codename'] }}
     - file: /etc/apt/sources.list.d/gift-ubuntu-stable-{{ grains['lsb_distrib_codename'] }}.list
     - refresh: True

--- a/remnux/repos/openjdk.sls
+++ b/remnux/repos/openjdk.sls
@@ -1,9 +1,19 @@
 include:
   - remnux.packages.software-properties-common
 
+openjdk-repo-key:
+  file.managed:
+    - name: /usr/share/keyrings/OPENJDK-PGP-KEY.asc
+    - source: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xda1a4a13543b466853baf164eb9b1d8886f44e2a
+    - skip_verify: True
+    - makedirs: True
+
 openjdk-repo:
   pkgrepo.managed:
-    - ppa: openjdk-r/ppa
+    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/OPENJDK-PGP-KEY.asc] https://ppa.launchpadcontent.net/openjdk-r/ppa/ubuntu {{ grains['lsb_distrib_codename'] }} main
+    - file: /etc/apt/sources.list.d/openjdk-r-ubuntu-ppa-{{ grains['lsb_distrib_codename'] }}.list
     - refresh: true
+    - clean_file: True
     - require:
       - sls: remnux.packages.software-properties-common
+      - file: openjdk-repo-key

--- a/remnux/repos/remnux.sls
+++ b/remnux/repos/remnux.sls
@@ -7,7 +7,7 @@ remnux-repo-key:
 
 remnux-repo:
   pkgrepo.managed:
-    - name: deb [signed-by=/usr/share/keyrings/REMNUX-GPG-KEY.asc] http://ppa.launchpad.net/remnux/stable/ubuntu {{ grains['lsb_distrib_codename'] }} main
+    - name: deb [signed-by=/usr/share/keyrings/REMNUX-GPG-KEY.asc] https://ppa.launchpadcontent.net/remnux/stable/ubuntu {{ grains['lsb_distrib_codename'] }} main
     - file: /etc/apt/sources.list.d/remnux-stable-{{ grains['lsb_distrib_codename'] }}.list
     - refresh: True
     - clean_file: True

--- a/remnux/repos/sift.sls
+++ b/remnux/repos/sift.sls
@@ -23,7 +23,7 @@ sift-repo-key:
 
 sift-repo:
   pkgrepo.managed:
-    - name: deb [signed-by=/usr/share/keyrings/SIFT-GPG-KEY.asc] http://ppa.launchpad.net/sift/stable/ubuntu {{ grains['lsb_distrib_codename'] }} main
+    - name: deb [signed-by=/usr/share/keyrings/SIFT-GPG-KEY.asc] https://ppa.launchpadcontent.net/sift/stable/ubuntu {{ grains['lsb_distrib_codename'] }} main
     - file: /etc/apt/sources.list.d/sift-stable-{{ grains['lsb_distrib_codename'] }}.list
     - refresh: True
     - clean_file: True

--- a/remnux/repos/wireshark-dev.sls
+++ b/remnux/repos/wireshark-dev.sls
@@ -1,4 +1,19 @@
+include:
+  - remnux.packages.software-properties-common
+
+wireshark-dev-repo-key:
+  file.managed:
+    - name: /usr/share/keyrings/WIRESHARK-DEV-PGP-KEY.asc
+    - source: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xa2e402b85a4b70cd78d8a3d9d875551314eca0f0
+    - skip_verify: True
+    - makedirs: True
+
 wireshark-dev:
   pkgrepo.managed:
-    - ppa: wireshark-dev/stable
+    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/WIRESHARK-DEV-PGP-KEY.asc] https://ppa.launchpadcontent.net/wireshark-dev/stable/ubuntu {{ grains['lsb_distrib_codename'] }} main
+    - file: /etc/apt/sources.list.d/wireshark-dev-ubuntu-stable-{{ grains['lsb_distrib_codename'] }}.list
     - refresh: true
+    - clean_file: True
+    - require:
+      - sls: remnux.packages.software-properties-common
+      - file: wireshark-dev-repo-key

--- a/remnux/tools/init.sls
+++ b/remnux/tools/init.sls
@@ -9,7 +9,6 @@ include:
   - remnux.tools.cyberchef
   - remnux.tools.cfr
   - remnux.tools.cutter
-  - remnux.tools.remnux-cli
   - remnux.tools.fakedns
   - remnux.tools.shellcode2exe-bat
   - remnux.tools.bytehist
@@ -39,7 +38,6 @@ remnux-tools:
       - sls: remnux.tools.cyberchef
       - sls: remnux.tools.cfr
       - sls: remnux.tools.cutter
-      - sls: remnux.tools.remnux-cli
       - sls: remnux.tools.fakedns
       - sls: remnux.tools.shellcode2exe-bat
       - sls: remnux.tools.bytehist

--- a/remnux/tools/remnux-cli.sls
+++ b/remnux/tools/remnux-cli.sls
@@ -1,6 +1,3 @@
-{%- set source = "https://github.com/REMnux/remnux-cli/releases/download/v1.3.9/remnux-cli-linux" -%}		
-{%- set hash = "88cd35b7807fc66ee8b51ee08d0d2518b2329c471b034ee3201e004c655be8d6" -%}		
-
 # Name: REMnux Installer
 # Website: https://github.com/REMnux/remnux-cli
 # Description: Install and upgrade the REMnux distro. 
@@ -9,9 +6,13 @@
 # License: MIT License: https://github.com/REMnux/remnux-cli/blob/master/LICENSE
 # Notes: remnux
 
+{%- set source = "https://github.com/REMnux/remnux-cli/releases/download/v" -%}		
+{% set hash = "88cd35b7807fc66ee8b51ee08d0d2518b2329c471b034ee3201e004c655be8d6" %}		
+{% set version = "1.3.9" %}
+
 remnux-tool-remnux-cli:
   file.managed:
     - name: /usr/local/bin/remnux
-    - source: {{ source }}
+    - source: {{ source }}{{ version }}/remnux-cli-linux
     - source_hash: sha256={{ hash }}
     - mode: 755


### PR DESCRIPTION
This PR makes some changes to the setuptools, pip, and wheel states to pin versions which do not appear to have any of the METADATA/RECORD issues. It also
- adds the requests package pinned at 2.31.0
- moves the remnux-cli state to the end of the installation (to avoid collisions with a previous and current version of remnux during a possibly failed install)
- removes the importlib-metadata state (since Salt 3006 comes with the fix for the previous issue)
- changes some of the repos to https vice http (fixing some recently discovered resolution issues)

I've tested this state in the most recent REMnux VM (built from the OVA, with no updates applied), docker packages and plain Ubuntu VM installations. All were successful and none had the previously defined issues.