### PR TITLE
Add Dissect to REMnux #251

### DIFF
--- a/remnux/config/dissect-venv.sh
+++ b/remnux/config/dissect-venv.sh
@@ -1,0 +1,13 @@
+dissect() {
+    . /opt/dissect/bin/activate
+
+    local dissect_target_dir=$(dirname $(/opt/dissect/bin/python3 -c "import dissect.target; print(dissect.target.__file__)"))
+    local autocompletion_dir="${dissect_target_dir}/data/autocompletion"
+
+    if [[ -d "$autocompletion_dir" ]]; then
+        for file in $autocompletion_dir/*;
+        do
+            source $file
+        done
+    fi
+}

--- a/remnux/packages/libfuse2.sls
+++ b/remnux/packages/libfuse2.sls
@@ -1,0 +1,2 @@
+libfuse2:
+  pkg.installed

--- a/remnux/packages/python39.sls
+++ b/remnux/packages/python39.sls
@@ -1,0 +1,2 @@
+python3.9:
+  pkg.installed

--- a/remnux/python3-packages/dissect.sls
+++ b/remnux/python3-packages/dissect.sls
@@ -1,0 +1,69 @@
+# Name: dissect
+# Website: https://github.com/fox-it/dissect
+# Description: Digital forensics & incident response framework and toolset.
+# Category: Gather and Analyze Data
+# Author: Dissect Team: dissect@fox-it.com
+# License: Affero General Public License v3 (https://github.com/fox-it/dissect/blob/main/LICENSE)
+# Notes: acquire, target-fs, rdump, rgeoip, target-query, target-shell, target-dump, target-info, target-reg, target-dd, target-mount
+
+{% set tools = ['acquire','target-query','target-shell','target-fs','target-reg','target-dump','target-dd','target-mount','rdump','rgeoip'] %}
+
+{% if grains['oscodename'] == "focal" %}
+  {% set py3_version="python3.9" %}
+  {% set py3_dependency="python39" %} 
+{% else %}
+  {% set py3_version="python3" %}
+  {% set py3_dependency="python3" %} 
+{% endif %}
+
+include:
+  - remnux.python3-packages.pip
+  - remnux.packages.python3-virtualenv
+  - remnux.packages.{{ py3_dependency }}
+  - remnux.packages.libfuse2
+
+# Create a virtualenv for dissect
+remnux-python3-packages-dissect-virtualenv:
+  virtualenv.managed:
+    - name: /opt/dissect
+    - python: /usr/bin/{{ py3_version }}
+    - pip_pkgs:
+      - pip>=23.1.2
+      - setuptools==67.7.2
+      - wheel==0.38.4
+      - tzdata
+    - require:
+      - sls: remnux.packages.{{ py3_dependency }}
+      - sls: remnux.python3-packages.pip
+      - sls: remnux.packages.python3-virtualenv
+
+# Install dissect inside the virtualenv
+remnux-python3-packages-dissect-install:
+  pip.installed:
+    - names:
+      - dissect
+      - maxminddb
+      - acquire
+    - bin_env: /opt/dissect/bin/python3
+    - upgrade: True
+    - user: root
+    - require:
+      - virtualenv: remnux-python3-packages-dissect-virtualenv
+
+remnux-python3-packages-dissect-venv-shortcut:
+  file.managed:
+    - name: /etc/profile.d/dissect-venv.sh
+    - source: salt://remnux/config/dissect-venv.sh
+    - makedirs: False
+    - require:
+      - pip: remnux-python3-packages-dissect-install
+
+{% for tool in tools %}
+remnux-python3-packages-dissect-{{ tool }}-symlink:
+  file.symlink:
+    - name: /usr/local/bin/{{ tool }}
+    - target: /opt/dissect/bin/{{ tool }}
+    - makedirs: False
+    - require:
+      - pip: remnux-python3-packages-dissect-install
+{% endfor %}

--- a/remnux/python3-packages/init.sls
+++ b/remnux/python3-packages/init.sls
@@ -54,6 +54,7 @@ include:
   - remnux.python3-packages.dotnetfile
   - remnux.python3-packages.debloat
   - remnux.python3-packages.peepdf-3
+  - remnux.python3-packages.dissect
 
 remnux-python3-packages:
   test.nop:
@@ -113,3 +114,4 @@ remnux-python3-packages:
       - sls: remnux.python3-packages.dotnetfile
       - sls: remnux.python3-packages.debloat
       - sls: remnux.python3-packages.peepdf-3
+      - sls: remnux.python3-packages.dissect


### PR DESCRIPTION
This is an updated version of the PR submitted by @Miauwkeru earlier in #251 . It updates the dissect-venv.sh file to point to the specific venv python3 binary so it won't change between Focal and Jammy, pins the pip, setuptools, and wheel packages for the venv to prevent the Python3 issue we've had in the past, and adds symlinks for each of the packages (pinned at the necessary version of python3 dependent on OS version).

This also adds acquire, and creates links for rdump, rgeoip, and includes the requirements for those. The tzdata package is required in Jammy to avoid noisy timezone messages.

Tested and works in both Focal and Jammy.