### PR TITLE
Fix errors with exiftool install

### DIFF
--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -40,7 +40,7 @@ include:
   - remnux.packages.libfuzzy-dev
   - remnux.packages.libjpeg-dev
   - remnux.packages.libjpeg8-dev
-  - remnux.packages.spidermonkey
+  - remnux.packages.liblzma-dev
   - remnux.packages.libncurses
   - remnux.packages.libsqlite3-dev
   - remnux.packages.libssl-dev
@@ -106,6 +106,7 @@ include:
   - remnux.packages.pdftk-java
   - remnux.packages.net-tools
   - remnux.packages.wine
+  - remnux.packages.spidermonkey
   - remnux.packages.galculator
   - remnux.packages.libjavassist-java
   - remnux.packages.vim
@@ -204,6 +205,7 @@ remnux-packages:
       - sls: remnux.packages.libfuzzy-dev
       - sls: remnux.packages.libjpeg-dev
       - sls: remnux.packages.libjpeg8-dev
+      - sls: remnux.packages.liblzma-dev
       - sls: remnux.packages.libncurses
       - sls: remnux.packages.libsqlite3-dev
       - sls: remnux.packages.libssl-dev

--- a/remnux/packages/liblzma-dev.sls
+++ b/remnux/packages/liblzma-dev.sls
@@ -1,0 +1,2 @@
+liblzma-dev:
+  pkg.installed

--- a/remnux/perl-packages/exiftool.sls
+++ b/remnux/perl-packages/exiftool.sls
@@ -9,6 +9,11 @@
 include:
   - remnux.packages.perl
   - remnux.packages.build-essential
+  - remnux.packages.liblzma-dev
+  - remnux.packages.libssl-dev
+  - remnux.packages.zlib1g-dev
+  - remnux.packages.unzip
+  - remnux.perl-packages.net-ssleay
 
 remnux-perl-packages-exiftool:
   cmd.run:
@@ -18,3 +23,8 @@ remnux-perl-packages-exiftool:
     - require:
       - sls: remnux.packages.perl
       - sls: remnux.packages.build-essential
+      - sls: remnux.packages.liblzma-dev
+      - sls: remnux.packages.libssl-dev
+      - sls: remnux.packages.zlib1g-dev
+      - sls: remnux.packages.unzip
+      - sls: remnux.perl-packages.net-ssleay

--- a/remnux/perl-packages/init.sls
+++ b/remnux/perl-packages/init.sls
@@ -5,6 +5,7 @@ include:
   - remnux.perl-packages.crypt-blowfish
   - remnux.perl-packages.digest-crc
   - remnux.perl-packages.ole-storagelite
+  - remnux.perl-packages.net-ssleay
 
 remnux-perl-packages:
   test.nop:
@@ -15,3 +16,4 @@ remnux-perl-packages:
       - sls: remnux.perl-packages.crypt-blowfish
       - sls: remnux.perl-packages.digest-crc
       - sls: remnux.perl-packages.ole-storagelite
+      - sls: remnux.perl-packages.net-ssleay

--- a/remnux/perl-packages/net-ssleay.sls
+++ b/remnux/perl-packages/net-ssleay.sls
@@ -1,0 +1,14 @@
+include:
+  - remnux.packages.perl
+  - remnux.packages.build-essential
+  - remnux.packages.libssl-dev
+
+remnux-perl-packages-net-ssleay-install:
+  cmd.run:
+    - name: cpan install Net::SSLeay
+    - env:
+      - PERL_MM_USE_DEFAULT: 1
+    - require:
+      - sls: remnux.packages.perl
+      - sls: remnux.packages.build-essential
+      - sls: remnux.packages.libssl-dev


### PR DESCRIPTION
This adds additional requirements to successfully install exiftool and avoid failures with the compilation. Original issue addressed [here](https://github.com/REMnux/remnux-cli/issues/159).