### PR TITLE
Update peepdf-3 requirements, header

### DIFF
--- a/remnux/python3-packages/init.sls
+++ b/remnux/python3-packages/init.sls
@@ -53,6 +53,7 @@ include:
   - remnux.python3-packages.dnfile
   - remnux.python3-packages.dotnetfile
   - remnux.python3-packages.debloat
+  - remnux.python3-packages.pylibemu
   - remnux.python3-packages.peepdf-3
   - remnux.python3-packages.dissect
 
@@ -113,5 +114,6 @@ remnux-python3-packages:
       - sls: remnux.python3-packages.dnfile
       - sls: remnux.python3-packages.dotnetfile
       - sls: remnux.python3-packages.debloat
+      - sls: remnux.python3-packages.pylibemu
       - sls: remnux.python3-packages.peepdf-3
       - sls: remnux.python3-packages.dissect

--- a/remnux/python3-packages/peepdf-3.sls
+++ b/remnux/python3-packages/peepdf-3.sls
@@ -1,5 +1,5 @@
-# Name: peepdf
-# Website: https://eternal-todo.com/tools/peepdf-pdf-analysis-tool
+# Name: peepdf-3
+# Website: https://github.com/digitalsleuth/peepdf-3
 # Description: Examine elements of the PDF file.
 # Category: Analyze Documents: PDF
 # Author: Jose Miguel Esparza and Corey Forman
@@ -13,10 +13,11 @@ include:
   - remnux.packages.zlib1g-dev
   - remnux.packages.git
   - remnux.python3-packages.stpyv8
+  - remnux.python3-packages.pylibemu
 
 remnux-tools-peepdf-3-source:
   pip.installed:
-    - name: git+https://github.com/digitalsleuth/peepdf-3.git
+    - name: peepdf-3
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:
@@ -26,3 +27,4 @@ remnux-tools-peepdf-3-source:
       - sls: remnux.packages.zlib1g-dev
       - sls: remnux.packages.git
       - sls: remnux.python3-packages.stpyv8
+      - sls: remnux.python3-packages.pylibemu

--- a/remnux/python3-packages/pylibemu.sls
+++ b/remnux/python3-packages/pylibemu.sls
@@ -1,0 +1,12 @@
+include:
+  - remnux.python3-packages.pip
+  - remnux.packages.libemu
+
+remnux-python3-packages-pylibemu:
+  pip.installed:
+    - name: pylibemu
+    - bin_env: /usr/bin/python3
+    - upgrade: True
+    - require:
+      - sls: remnux.python3-packages.pip
+      - sls: remnux.packages.libemu


### PR DESCRIPTION
I've just released a new major version of peepdf-3 which will no longer "require" pylibemu or libemu for the installation, allowing it to be used without shellcode analysis on Windows and Linux platforms. The shellcode analysis function still exists with the installation of libemu and pylibemu, so this PR will modify the state to now include them, since they're no longer included as a requirement.