### PR TITLE
Move thug, qiling, speakeasy, nth to venv

### DIFF
--- a/remnux/packages/python-dev.sls
+++ b/remnux/packages/python-dev.sls
@@ -1,2 +1,0 @@
-python-dev:
-  pkg.installed

--- a/remnux/packages/python3-dev.sls
+++ b/remnux/packages/python3-dev.sls
@@ -1,0 +1,2 @@
+python3-dev:
+  pkg.installed

--- a/remnux/packages/python39-dev.sls
+++ b/remnux/packages/python39-dev.sls
@@ -1,0 +1,2 @@
+python3.9-dev:
+  pkg.installed

--- a/remnux/python3-packages/dissect.sls
+++ b/remnux/python3-packages/dissect.sls
@@ -19,6 +19,7 @@
 include:
   - remnux.python3-packages.pip
   - remnux.packages.python3-virtualenv
+  - remnux.packages.virtualenv
   - remnux.packages.{{ py3_dependency }}
   - remnux.packages.libfuse2
 

--- a/remnux/python3-packages/name-that-hash.sls
+++ b/remnux/python3-packages/name-that-hash.sls
@@ -8,10 +8,32 @@
 
 include:
   - remnux.python3-packages.pip
+  - remnux.packages.virtualenv
+
+remnux-python3-packages-name-that-hash-virtualenv:
+  virtualenv.managed:
+    - name: /opt/nth
+    - python: /usr/bin/python3
+    - pip_pkgs:
+      - pip>=23.1.2
+      - setuptools==67.7.2
+      - wheel==0.38.4
+    - require:
+      - sls: remnux.packages.virtualenv
+      - sls: remnux.python3-packages.pip
 
 remnux-python3-packages-name-that-hash-install:
   pip.installed:
     - name: name-that-hash
-    - bin_env: /usr/bin/python3
+    - bin_env: /opt/nth/bin/python3
+    - upgrade: True
     - require:
-      - sls: remnux.python3-packages.pip
+      - virtualenv: remnux-python3-packages-name-that-hash-virtualenv
+
+remnux-python3-packages-name-that-hash-symlink:
+  file.symlink:
+    - name: /usr/local/bin/nth
+    - target: /opt/nth/bin/nth
+    - makedirs: False
+    - require:
+      - pip: remnux-python3-packages-name-that-hash-install

--- a/remnux/python3-packages/qiling.sls
+++ b/remnux/python3-packages/qiling.sls
@@ -7,21 +7,36 @@
 # Notes: Use `qltool` to analyze artifacts. Before analyzing Windows artifacts, gather Windows DLLs and other components using the [dllscollector.bat](https://github.com/qilingframework/qiling/blob/master/examples/scripts/dllscollector.bat) script. Read the tool's [documentation](https://docs.qiling.io) to get started.
 
 include:
+  - remnux.packages.virtualenv
   - remnux.python3-packages.pip
 
-remnux-python3-packages-qiling-yaml:
-  pip.installed:
-    - bin_env: /usr/bin/python3
-    - upgrade: True
-    - name: pyyaml
-    - ignore_installed: True
+remnux-python3-packages-qiling-virtualenv:
+  virtualenv.managed:
+    - name: /opt/qiling
+    - venv_bin: /usr/bin/virtualenv
+    - python: /usr/bin/python3
+    - pip_pkgs:
+      - pip>=23.1.2
+      - setuptools==67.7.2
+      - wheel==0.38.4
+      - pyyaml
+      - six
     - require:
-      - sls: remnux.python3-packages.pip
+      - sls: remnux.packages.virtualenv
+      - sls: remnux.packages.python3-pip
 
 remnux-python3-packages-qiling:
   pip.installed:
     - name: qiling
-    - bin_env: /usr/bin/python3
+    - bin_env: /opt/qiling/bin/python3
     - upgrade: True
     - require:
-      - pip: remnux-python3-packages-qiling-yaml
+      - virtualenv: remnux-python3-packages-qiling-virtualenv
+
+remnux-python3-packages-qiling-symlink:
+  file.symlink:
+    - name: /usr/local/bin/qltool
+    - target: /opt/qiling/bin/qltool
+    - makedirs: False
+    - require:
+      - pip: remnux-python3-packages-qiling

--- a/remnux/python3-packages/stpyv8.sls
+++ b/remnux/python3-packages/stpyv8.sls
@@ -5,6 +5,7 @@
 # Author: Area1 Security
 # License: Apache License 2.0: https://github.com/cloudflare/stpyv8/blob/master/LICENSE.txt
 # Notes:
+
 {%- set version="11.7.439.19" %}
 {%- if grains['oscodename'] == "bionic" %} 
 Ubuntu Bionic is no longer supported:
@@ -14,6 +15,7 @@ Ubuntu Bionic is no longer supported:
   {%- set hash="bf6821faf6669e07057478edf22c0e02351e7922494dbff377f216920235d8b7" %}
   {%- set wheel="stpyv8-" + version + "-cp38-cp38-linux_x86_64.whl" %}
   {%- set folder="stpyv8-ubuntu-20.04-3.8" %}
+{%- endif %}
 
 include:
   - remnux.packages.sudo
@@ -52,4 +54,3 @@ remnux-pip3-stpyv8:
       - sls: remnux.packages.libboost-dev
       - sls: remnux.packages.libboost-iostreams-dev
       - sls: remnux.python3-packages.setuptools
-{%- endif %}

--- a/remnux/python3-packages/thug.sls
+++ b/remnux/python3-packages/thug.sls
@@ -6,6 +6,23 @@
 # License: GNU General Public License (GPL) v2: https://github.com/buffer/thug/blob/master/LICENSE.txt
 # Notes: thug -F
 
+{%- set version="11.7.439.19" %}
+{% if grains['oscodename'] == "focal" %}
+  {% set py3_version="python3.9" %}
+  {% set py3_dependency="python39" %} 
+  {%- set release="stpyv8-ubuntu-20.04-python-3.9.zip" %}
+  {%- set hash="b595998a67a9b70b9d97dc22fd0e36674f60629790f250458681413912692b8a" %}
+  {%- set wheel="stpyv8-" + version + "-cp39-cp39-linux_x86_64.whl" %}
+  {%- set folder="stpyv8-ubuntu-20.04-3.9" %}
+{% elif grains['oscodename'] == "jammy" %}
+  {% set py3_version="python3" %}
+  {% set py3_dependency="python3" %} 
+  {%- set release="stpyv8-ubuntu-22.04-python-3.10.zip" %}
+  {%- set hash="757bb89229c659d517c23ec6fae56f5c76437fc3a72bbac7584805efcbe0b19e" %}
+  {%- set wheel="stpyv8-" + version + "-cp310-cp310-linux_x86_64.whl" %}
+  {%- set folder="stpyv8-ubuntu-22.04-3.10" %}
+{% endif %}
+
 include:
   - remnux.packages.git
   - remnux.python3-packages.pip
@@ -19,8 +36,62 @@ include:
   - remnux.packages.libfuzzy2
   - remnux.packages.libjpeg-dev
   - remnux.packages.tesseract-ocr
-  - remnux.python3-packages.stpyv8
+  - remnux.packages.libssl-dev
   - remnux.python3-packages.pytesseract
+  - remnux.packages.virtualenv
+  - remnux.packages.{{ py3_dependency }}
+  - remnux.packages.{{ py3_dependency }}-dev
+  - remnux.packages.sudo
+  - remnux.packages.libboost-python-dev
+  - remnux.packages.libboost-system-dev
+  - remnux.packages.libboost-iostreams-dev
+  - remnux.packages.libboost-dev
+  - remnux.packages.build-essential
+
+remnux-python3-packages-thug-virtualenv:
+  virtualenv.managed:
+    - name: /opt/thug
+    - venv_bin: /usr/bin/virtualenv
+    - python: /usr/bin/{{ py3_version }}
+    - pip_pkgs:
+      - pip>=23.1.2
+      - setuptools==67.7.2
+      - wheel==0.38.4
+      - "yara-python"
+    - require:
+      - sls: remnux.packages.{{ py3_dependency }}
+      - sls: remnux.packages.virtualenv
+      - sls: remnux.packages.{{ py3_dependency }}-dev
+
+remnux-python3-packages-thug-venv-stpyv8-source:
+  file.managed:
+    - name: /usr/local/src/remnux/files/{{ release }}
+    - source: https://github.com/cloudflare/stpyv8/releases/download/v{{ version }}/{{ release }}
+    - source_hash: sha256={{ hash }}
+    - makedirs: True
+
+remnux-python3-packages-thug-venv-stpyv8-archive:
+  archive.extracted:
+    - name: /usr/local/src/remnux/
+    - source: /usr/local/src/remnux/files/{{ release }}
+    - enforce_toplevel: False
+    - watch:
+      - file: remnux-python3-packages-thug-venv-stpyv8-source
+
+remnux-python3-packages-thug-venv-stpyv8-pip:
+  pip.installed:
+    - name: /usr/local/src/remnux/{{ folder }}/{{ wheel }}
+    - bin_env: /opt/thug/bin/python3
+    - require:
+      - sls: remnux.python3-packages.pip
+      - sls: remnux.packages.sudo
+      - sls: remnux.packages.libboost-python-dev
+      - sls: remnux.packages.libboost-system-dev
+      - sls: remnux.packages.libboost-dev
+      - sls: remnux.packages.libboost-iostreams-dev
+      - sls: remnux.python3-packages.setuptools
+      - file: remnux-python3-packages-thug-venv-stpyv8-source
+      - archive: remnux-python3-packages-thug-venv-stpyv8-archive
 
 remnux-python3-packages-thug-git:
   git.latest:
@@ -30,14 +101,18 @@ remnux-python3-packages-thug-git:
     - force_reset: True
     - force_checkout: True
     - force_fetch: True
+    - require:
+      - sls: remnux.packages.git
 
 remnux-python3-packages-thug-packages:
   pip.installed:
     - name: thug
-    - bin_env: /usr/bin/python3
+    - bin_env: /opt/thug/bin/python3
     - upgrade: True
     - require:
       - sls: remnux.python3-packages.pip
+      - virtualenv: remnux-python3-packages-thug-virtualenv
+      - sls: remnux.packages.libssl-dev
     - watch:
       - git: remnux-python3-packages-thug-git
 
@@ -52,8 +127,16 @@ remnux-python3-packages-thug-makedir:
     - watch:
       - pip: remnux-python3-packages-thug-packages
 
-emnux-python3-packages-thug-conf:
+remnux-python3-packages-thug-conf:
   cmd.run:
     - name: cp -R /usr/local/src/thug/thug/conf/* /etc/thug
     - watch:
       - file: remnux-python3-packages-thug-makedir
+
+remnux-python3-packages-thug-symlink:
+  file.symlink:
+    - name: /usr/local/bin/thug
+    - target: /opt/thug/bin/thug
+    - makedirs: False
+    - require:
+      - pip: remnux-python3-packages-thug-packages


### PR DESCRIPTION
This PR moves speakeasy, qiling, thug and name-that-hash to virtualenv. This will resolve most of the python3 requirement conflicts. It will also resolve issue #265.