### PR TITLE
Fix venv symlink issues

### DIFF
--- a/remnux/python3-packages/name-that-hash.sls
+++ b/remnux/python3-packages/name-that-hash.sls
@@ -10,6 +10,11 @@ include:
   - remnux.python3-packages.pip
   - remnux.packages.virtualenv
 
+remnux-python3-packages-remove-name-that-hash:
+  pip.removed:
+    - name: name-that-hash
+    - bin_env: /usr/bin/python3
+
 remnux-python3-packages-name-that-hash-virtualenv:
   virtualenv.managed:
     - name: /opt/nth
@@ -21,6 +26,7 @@ remnux-python3-packages-name-that-hash-virtualenv:
     - require:
       - sls: remnux.packages.virtualenv
       - sls: remnux.python3-packages.pip
+      - pip: remnux-python3-packages-remove-name-that-hash
 
 remnux-python3-packages-name-that-hash-install:
   pip.installed:
@@ -35,5 +41,6 @@ remnux-python3-packages-name-that-hash-symlink:
     - name: /usr/local/bin/nth
     - target: /opt/nth/bin/nth
     - makedirs: False
+    - force: True
     - require:
       - pip: remnux-python3-packages-name-that-hash-install

--- a/remnux/python3-packages/qiling.sls
+++ b/remnux/python3-packages/qiling.sls
@@ -10,6 +10,11 @@ include:
   - remnux.packages.virtualenv
   - remnux.python3-packages.pip
 
+remnux-python3-packages-remove-qiling:
+  pip.removed:
+    - name: qiling
+    - bin_env: /usr/bin/python3
+
 remnux-python3-packages-qiling-virtualenv:
   virtualenv.managed:
     - name: /opt/qiling
@@ -24,6 +29,7 @@ remnux-python3-packages-qiling-virtualenv:
     - require:
       - sls: remnux.packages.virtualenv
       - sls: remnux.packages.python3-pip
+      - pip: remnux-python3-packages-remove-qiling
 
 remnux-python3-packages-qiling:
   pip.installed:
@@ -38,5 +44,6 @@ remnux-python3-packages-qiling-symlink:
     - name: /usr/local/bin/qltool
     - target: /opt/qiling/bin/qltool
     - makedirs: False
+    - force: True
     - require:
       - pip: remnux-python3-packages-qiling

--- a/remnux/python3-packages/speakeasy.sls
+++ b/remnux/python3-packages/speakeasy.sls
@@ -13,6 +13,11 @@ include:
   - remnux.packages.git
   - remnux.packages.virtualenv
 
+remnux-python3-packages-remove-speakeasy:
+  pip.removed:
+    - name: speakeasy
+    - bin_env: /usr/bin/python3
+
 remnux-python3-packages-speakeasy-virtualenv:
   virtualenv.managed:
     - name: /opt/speakeasy
@@ -25,6 +30,7 @@ remnux-python3-packages-speakeasy-virtualenv:
     - require:
       - sls: remnux.packages.virtualenv
       - sls: remnux.packages.python3-pip
+      - pip: remnux-python3-packages-remove-speakeasy
 
 remnux-python3-packages-speakeasy-requirements:
   pip.installed:
@@ -90,6 +96,7 @@ remnux-python3-packages-speakeasy-{{ tool }}-symlink:
     - name: /usr/local/bin/{{ tool }}
     - target: /opt/speakeasy/bin/{{ tool }}
     - makedirs: False
+    - force: True
     - require:
       - pip: remnux-python3-packages-speakeasy
 {% endfor %}

--- a/remnux/python3-packages/thug.sls
+++ b/remnux/python3-packages/thug.sls
@@ -48,6 +48,11 @@ include:
   - remnux.packages.libboost-dev
   - remnux.packages.build-essential
 
+remnux-python3-packages-remove-thug:
+  pip.removed:
+    - name: thug
+    - bin_env: /usr/bin/python3
+
 remnux-python3-packages-thug-virtualenv:
   virtualenv.managed:
     - name: /opt/thug
@@ -62,6 +67,7 @@ remnux-python3-packages-thug-virtualenv:
       - sls: remnux.packages.{{ py3_dependency }}
       - sls: remnux.packages.virtualenv
       - sls: remnux.packages.{{ py3_dependency }}-dev
+      - pip: remnux-python3-packages-remove-thug
 
 remnux-python3-packages-thug-venv-stpyv8-source:
   file.managed:
@@ -138,5 +144,6 @@ remnux-python3-packages-thug-symlink:
     - name: /usr/local/bin/thug
     - target: /opt/thug/bin/thug
     - makedirs: False
+    - force: True
     - require:
       - pip: remnux-python3-packages-thug-packages


### PR DESCRIPTION
This fixes the errors which came up with the introduction of the virtualenv states. This will uninstall the previous package from the `/usr/bin/python3` environment and create a symlink to the new virtualenv file.