### PR TITLE
Update pip git installs

### DIFF
--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -121,7 +121,6 @@ include:
   - remnux.packages.dex2jar
   - remnux.packages.netcat
   - remnux.packages.python3-pyqt5
-  - remnux.packages.fakenet-ng
   - remnux.packages.vscode
   - remnux.packages.bearparser
   - remnux.packages.signsrch
@@ -286,7 +285,6 @@ remnux-packages:
       - sls: remnux.packages.dex2jar
       - sls: remnux.packages.netcat
       - sls: remnux.packages.python3-pyqt5
-      - sls: remnux.packages.fakenet-ng
       - sls: remnux.packages.vscode
       - sls: remnux.packages.bearparser
       - sls: remnux.packages.signsrch

--- a/remnux/python-packages/fakenet-ng.sls
+++ b/remnux/python-packages/fakenet-ng.sls
@@ -20,45 +20,22 @@ include:
   - remnux.packages.python2-dev
 {% endif %}
 
-pydivert:
+remnux-python-packages-fakenet-requirements:
   pip.installed:
-    - bin_env: /usr/bin/python2
-    - require:
-      - sls: remnux.packages.python2-pip
-
-dnslib:
-  pip.installed:
-    - bin_env: /usr/bin/python2
-    - require:
-      - sls: remnux.packages.python2-pip
-
-dpkt:
-  pip.installed:
-    - bin_env: /usr/bin/python2
-    - require:
-      - sls: remnux.packages.python2-pip
-
-netfilterqueue:
-  pip.installed:
-    - bin_env: /usr/bin/python2
-    - require:
-      - sls: remnux.packages.python2-pip
-
-pyftpdlib:
-  pip.installed:
-    - bin_env: /usr/bin/python2
-    - require:
-      - sls: remnux.packages.python2-pip
-
-pyopenssl:
-  pip.installed:
+    - names:
+      - pydivert
+      - dnslib
+      - dpkt
+      - netfilterqueue
+      - pyftpdlib
+      - pyopenssl
     - bin_env: /usr/bin/python2
     - require:
       - sls: remnux.packages.python2-pip
 
 fakenet-ng:
   pip.installed:
-    - name: git+https://github.com/fireeye/flare-fakenet-ng
+    - name: git+https://github.com/fireeye/flare-fakenet-ng.git
     - bin_env: /usr/bin/python2
     - require:
       - sls: remnux.packages.git

--- a/remnux/python-packages/init.sls
+++ b/remnux/python-packages/init.sls
@@ -22,6 +22,7 @@ include:
   - remnux.python-packages.ioc-writer
   - remnux.python-packages.balbuzard
   - remnux.python-packages.poster
+  - remnux.python-packages.fakenet-ng
 
 remnux-python-packages:
   test.nop:
@@ -49,3 +50,4 @@ remnux-python-packages:
       - sls: remnux.python-packages.ioc-writer
       - sls: remnux.python-packages.balbuzard
       - sls: remnux.python-packages.poster
+      - sls: remnux.python-packages.fakenet-ng

--- a/remnux/python3-packages/dotnetfile.sls
+++ b/remnux/python3-packages/dotnetfile.sls
@@ -8,15 +8,13 @@
 
 include:
   - remnux.python3-packages.pip
-  - remnux.packages.git
 
 remnux-python3-packages-dotnetfile:
   pip.installed:
-    - name: git+https://github.com/pan-unit42/dotnetfile
+    - name: dotnetfile
     - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.python3-packages.pip
-      - sls: remnux.packages.git
 
 remnux-python3-packages-dotnetfile-dump:
   file.managed:

--- a/remnux/python3-packages/ioc-parser.sls
+++ b/remnux/python3-packages/ioc-parser.sls
@@ -12,7 +12,7 @@ include:
 
 remnux-python3-packages-ioc-parser:
   pip.installed:
-    - name: git+https://github.com/buffer/ioc_parser
+    - name: git+https://github.com/buffer/ioc_parser.git
     - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.python3-packages.pip

--- a/remnux/python3-packages/msg-extractor.sls
+++ b/remnux/python3-packages/msg-extractor.sls
@@ -8,14 +8,42 @@
 
 include:
   - remnux.python3-packages.pip
-  - remnux.packages.git
   - remnux.packages.tzdata
+  - remnux.packages.virtualenv
+
+remnux-python3-packages-remove-extract-msg:
+  pip.removed:
+    - name: extract_msg
+    - bin_env: /usr/bin/python3
+
+remnux-python3-packages-extract-msg-virtualenv:
+  virtualenv.managed:
+    - name: /opt/extract-msg
+    - venv_bin: /usr/bin/virtualenv
+    - python: /usr/bin/python3
+    - pip_pkgs:
+      - pip>=23.1.2
+      - setuptools==67.7.2
+      - wheel==0.38.4
+    - require:
+      - sls: remnux.packages.virtualenv
+      - sls: remnux.python3-packages.pip
+      - pip: remnux-python3-packages-remove-extract-msg
 
 remnux-python3-packages-extract-msg:
   pip.installed:
-    - name: git+https://github.com/TeamMsgExtractor/msg-extractor
-    - bin_env: /usr/bin/python3
+    - name: extract_msg
+    - bin_env: /opt/extract-msg/bin/python3
     - require:
       - sls: remnux.python3-packages.pip
-      - sls: remnux.packages.git
       - sls: remnux.packages.tzdata
+      - virtualenv: remnux-python3-packages-extract-msg-virtualenv
+
+remnux-python3-packages-extract-msg-symlink:
+  file.symlink:
+    - name: /usr/local/bin/extract_msg
+    - target: /opt/extract-msg/bin/extract_msg
+    - makedirs: False
+    - force: True
+    - require:
+      - pip: remnux-python3-packages-extract-msg

--- a/remnux/python3-packages/speakeasy.sls
+++ b/remnux/python3-packages/speakeasy.sls
@@ -32,23 +32,15 @@ remnux-python3-packages-speakeasy-virtualenv:
       - sls: remnux.packages.python3-pip
       - pip: remnux-python3-packages-remove-speakeasy
 
-remnux-python3-packages-speakeasy-requirements:
-  pip.installed:
-    - bin_env: /opt/speakeasy/bin/python3
-    - requirements: https://raw.githubusercontent.com/mandiant/speakeasy/master/requirements.txt
-    - require:
-      - virtualenv: remnux-python3-packages-speakeasy-virtualenv
-
 remnux-python3-packages-speakeasy:
   pip.installed:
     - bin_env: /opt/speakeasy/bin/python3
-    - name: git+https://github.com/mandiant/speakeasy.git
+    - name: speakeasy-emulator
     - branch: master
     - upgrade: True
     - require:
       - sls: remnux.python3-packages.pip
       - sls: remnux.packages.git
-      - pip: remnux-python3-packages-speakeasy-requirements
 
 remnux-python3-packages-speakeasy-emuexe:
   file.managed:

--- a/remnux/python3-packages/unfurl.sls
+++ b/remnux/python3-packages/unfurl.sls
@@ -11,21 +11,12 @@ include:
   - remnux.python3-packages.pip
   - remnux.packages.git
 
-remnux-python3-packages-unfurl-requirements:
-  pip.installed:
-    - bin_env: /usr/bin/python3
-    - requirements: https://raw.githubusercontent.com/obsidianforensics/unfurl/main/requirements.txt
-    - ignore_installed: True
-    - require:
-      - sls: remnux.python3-packages.pip
-      - sls: remnux.python3-packages.protobuf
-
 remnux-python3-packages-unfurl:
   pip.installed:
     - bin_env: /usr/bin/python3
-    - name: git+https://github.com/obsidianforensics/unfurl.git
+    - name: dfir-unfurl
     - ignore_installed: True
     - require:
       - sls: remnux.python3-packages.pip
       - sls: remnux.packages.git
-      - pip: remnux-python3-packages-unfurl-requirements
+      - sls: remnux.python3-packages.protobuf

--- a/remnux/python3-packages/virustotal-api.sls
+++ b/remnux/python3-packages/virustotal-api.sls
@@ -8,13 +8,10 @@
 
 include:
   - remnux.python3-packages.pip
-  - remnux.packages.git
 
 remnux-python3-package-virustotal-api:
   pip.installed:
-    - name: git+https://github.com/doomedraven/VirusTotalApi
+    - name: vt-py
     - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.python3-packages.pip
-      - sls: remnux.packages.git
-

--- a/remnux/python3-packages/volatility3.sls
+++ b/remnux/python3-packages/volatility3.sls
@@ -8,17 +8,20 @@
 
 include:
   - remnux.packages.git
-  - remnux.python3-packages.pefile
   - remnux.python3-packages.pip
+
+remnux-python3-packages-volatility3-requirements:
+  pip.installed:
+    - requirements: https://raw.githubusercontent.com/volatilityfoundation/volatility3/develop/requirements.txt
+    - bin_env: /usr/bin/python3
 
 remnux-python3-packages-volatility3:
   pip.installed:
-    - name: git+https://github.com/volatilityfoundation/volatility3.git
+    - name: volatility3
     - bin_env: /usr/bin/python3
     - require:
       - sls: remnux.packages.git
       - sls: remnux.python3-packages.pip
-      - sls: remnux.python3-packages.pefile
 
 remnux-python3-packages-volatility-rename-vol:
   file.rename:


### PR DESCRIPTION
A few of the python3 states which install using pip over git now have reliable pypi packages which are up-to-date. This PR will move these to install via pypi. It also moves the fakenet-ng state to python-packages, and puts extract_msg into a virtualenv, as it has very specific requirements.