### PR TITLE
Update m2crypto version

### DIFF
--- a/remnux/python-packages/m2crypto.sls
+++ b/remnux/python-packages/m2crypto.sls
@@ -7,7 +7,7 @@ include:
 
 remnux-python-packages-m2crypto:
   pip.installed:
-    - name: m2crypto
+    - name: m2crypto==0.40.1
     - bin_env: /usr/bin/python2
     - upgrade: True
     - require:
@@ -25,7 +25,7 @@ include:
 
 remnux-python-packages-m2crypto:
   pip.installed:
-    - name: m2crypto
+    - name: m2crypto==0.40.1
     - bin_env: /usr/bin/python2
     - upgrade: True
     - require:


### PR DESCRIPTION
Due to a recent update to m2crypto, python2 is no longer supported with version 0.41.0 and up. Given that m2crypto is a requirement for the Python 2 version of volatility, this PR will pin the version of m2crypto to 0.40.1, which is the last version to support Python 2.