### PR TITLE
fix: bump different packages versions

### DIFF
--- a/remnux/packages/radare2.sls
+++ b/remnux/packages/radare2.sls
@@ -6,8 +6,8 @@
 # License: GNU Lesser General Public License (LGPL) v3: https://github.com/radareorg/radare2/blob/master/COPYING
 # Notes: r2, rasm2, rabin2, rahash2, rafind2
 
-{% set version = '5.8.8' %}
-{% set hash = '691e510a900852d0b818f026bc111d0da24563ea414d569fa83737db57944e2e' %}
+{% set version = '5.9.0' %}
+{% set hash = '7164ab19c7c44dc47e3a3546b6a5335fa4e1713631afd8da916f921f9b7c0716' %}
 {% set installed_version = salt['cmd.shell']("dpkg -l | grep radare2 | awk '{print $3}'") %}
 
 include:

--- a/remnux/tools/apktool.sls
+++ b/remnux/tools/apktool.sls
@@ -6,8 +6,8 @@
 # License: Apache License 2.0: https://github.com/iBotPeaches/Apktool/blob/master/LICENSE
 # Notes: 
 
-{% set hash = 'c11b5eb518d9ac2ab18e959cbe087499079072b04d567cdcae5ceb447f9a7e7d' %}
-{% set version = '2.7.0' %}
+{% set hash = '7956eb04194300ce0d0a84ad18771eebc94b89fb8d1ddcce8ea4c056818646f4' %}
+{% set version = '2.9.3' %}
 
 include:
   - remnux.packages.default-jre

--- a/remnux/tools/cyberchef.sls
+++ b/remnux/tools/cyberchef.sls
@@ -6,8 +6,8 @@
 # License: Apache License 2.0: https://github.com/gchq/CyberChef/blob/master/LICENSE
 # Notes: cyberchef
 
-{% set version = "9.55.0" -%}
-{% set hash = "da55adc790d011f6bf3740e7e704d340351f7e1c8ebd8e7d9dd24aa46562307c" -%}
+{% set version = "10.18.3" -%}
+{% set hash = "fef9875c6c389539a8ed76ad765496d80061e9350b257b2b1aeec0b96090e40a" -%}
 
 include:
   - remnux.packages.firefox

--- a/remnux/tools/detect-it-easy.sls
+++ b/remnux/tools/detect-it-easy.sls
@@ -6,10 +6,10 @@
 # License: MIT License: https://github.com/horsicq/Detect-It-Easy/blob/master/LICENSE
 # Notes: GUI tool: `die`, command-line tool: `diec`.
 
-{% set version = '3.08' %}
+{% set version = '3.09' %}
 {%- if grains['oscodename'] == "focal" %}
 {% set release = '20.04' %}
-{% set hash = 'd02e79da976501dc665af07c53ad5501dc4ce0d606277bc5108456de3238c777' %}
+{% set hash = '198e154da31cc202e0a32b9dfb2a3ca99b5870404fc4023bf000217bd750fd5c' %}
 include:
   - remnux.packages.libglib2
   - remnux.packages.qt5-default

--- a/remnux/tools/docker-compose.sls
+++ b/remnux/tools/docker-compose.sls
@@ -1,5 +1,5 @@
-{% set version = "2.23.3" %}
-{% set hash = "a836e807951db448f991f303cddcc9a4ec69f4a49d58bc7d536cb91c77c04c33" %}
+{% set version = "2.27.0" %}
+{% set hash = "f3ba3bf1e4ab18e96c2d36526a075a02a78fb5f8e80d3e3ca9c5bf256d81d0a0" %}
 
 include:
   - remnux.python3-packages.pip


### PR DESCRIPTION
Checked some issues and bumped versions for R2. Did not find the quick way to bump Ghidra though.

I did the same for a quick update for different packages, everything is made commit by commit.

Note: inspicrd last release does not support ubuntu 18.0.4 thus the current version config condition needs an update I guess.

Have a nice day