### PR TITLE
Add magika

### DIFF
--- a/remnux/python3-packages/init.sls
+++ b/remnux/python3-packages/init.sls
@@ -55,6 +55,7 @@ include:
   - remnux.python3-packages.pylibemu
   - remnux.python3-packages.peepdf-3
   - remnux.python3-packages.dissect
+  - remnux.python3-packages.magika
 
 remnux-python3-packages:
   test.nop:
@@ -115,3 +116,4 @@ remnux-python3-packages:
       - sls: remnux.python3-packages.pylibemu
       - sls: remnux.python3-packages.peepdf-3
       - sls: remnux.python3-packages.dissect
+      - sls: remnux.python3-packages.magika

--- a/remnux/python3-packages/magika.sls
+++ b/remnux/python3-packages/magika.sls
@@ -1,0 +1,40 @@
+# Name: Magika
+# Website: https://google.github.io/magika/
+# Description: File type detection and analysis
+# Category: Examine Static Properties
+# Author: Google
+# License: Apache License 2.0 (https://github.com/google/magika/blob/main/LICENSE)
+# Notes:
+
+include:
+  - remnux.packages.python3-pip
+  - remnux.packages.virtualenv
+
+remnux-python3-packages-magika-venv:
+  virtualenv.managed:
+    - name: /opt/magika
+    - python: /usr/bin/python3
+    - pip_pkgs:
+      - pip>=23.1.2
+      - setuptools==67.7.2
+      - wheel==0.38.4
+    - require:
+      - sls: remnux.packages.virtualenv
+      - sls: remnux.packages.python3-pip
+
+remnux-python3-packages-magika-install:
+  pip.installed:
+    - name: magika
+    - bin_env: /opt/magika/bin/python3
+    - upgrade: True
+    - require:
+      - sls: remnux.packages.python3-pip
+      - virtualenv: remnux-python3-packages-magika-venv
+
+remnux-python3-packages-magika-symlink:
+  file.symlink:
+    - name: /usr/local/bin/magika
+    - target: /opt/magika/bin/magika
+    - makedirs: False
+    - require:
+      - pip: remnux-python3-packages-magika-install


### PR DESCRIPTION
As suggested in Issue #280, this will add the Magika file identification software from Google in a Python3 virtual environment.