### PR TITLE
Pin frida-tools temporarily

### DIFF
--- a/remnux/python3-packages/frida.sls
+++ b/remnux/python3-packages/frida.sls
@@ -11,7 +11,7 @@ include:
 
 remnux-python3-packages-frida-install:
   pip.installed:
-    - name: frida-tools
+    - name: frida-tools==12.3.0
     - bin_env: /usr/bin/python3
     - upgrade: True
     - require:


### PR DESCRIPTION
This will currently address the issue referenced in [REMnux-CLI Issue 178](https://github.com/REMnux/remnux-cli/issues/178), which is also identified in frida-tools [Issue 158](https://github.com/frida/frida-tools/issues/158). At this time, 12.3.0 is the latest version which does not have the identified issue during installation.