### PR TITLE
Restores the malwoverview config path to root

### DIFF
--- a/remnux/python3-packages/malwoverview.sls
+++ b/remnux/python3-packages/malwoverview.sls
@@ -57,7 +57,7 @@ remnux-python3-packages-malwoverview-install:
 remnux-python3-packages-malwoverview-config-file:
   file.managed:
     - name: {{ home }}/.malwapi.conf
-    - source: /opt/malwoverview/lib/{{ python3_version }}/site-packages/home/aborges/.malwapi.conf
+    - source: /opt/malwoverview/lib/{{ python3_version }}/site-packages/root/.malwapi.conf
     - user: {{ user }}
     - group: {{ user }}
     - makedirs: False


### PR DESCRIPTION
The issue previously experienced with malwoverview's config file has been resolved (see [Issue 43](https://github.com/alexandreborges/malwoverview/issues/43)), and the path restored to `root` vice `home/aborges`.

This PR restores the previous path location for the config file.