### PR TITLE
Temporarily remove fakenet from installation process

### DIFF
--- a/remnux/python-packages/init.sls
+++ b/remnux/python-packages/init.sls
@@ -22,7 +22,7 @@ include:
   - remnux.python-packages.ioc-writer
   - remnux.python-packages.balbuzard
   - remnux.python-packages.poster
-  - remnux.python-packages.fakenet-ng
+#  - remnux.python-packages.fakenet-ng
 
 remnux-python-packages:
   test.nop:
@@ -50,4 +50,4 @@ remnux-python-packages:
       - sls: remnux.python-packages.ioc-writer
       - sls: remnux.python-packages.balbuzard
       - sls: remnux.python-packages.poster
-      - sls: remnux.python-packages.fakenet-ng
+#      - sls: remnux.python-packages.fakenet-ng


### PR DESCRIPTION
In response to [Issue 188](https://github.com/REMnux/remnux-cli/issues/188), this PR will remove fakenet from the installation process, as pyftpdlib (a requirement for the install) has dropped support for Python 2 (the current means of installation).

Additionally, the Python 3 version of fakenet-ng is still not fully released and functional, so it is not in a state to optimally replace the current process. 