### PR TITLE
Fix dissect requirements

### DIFF
--- a/remnux/packages/liblzo2-dev.sls
+++ b/remnux/packages/liblzo2-dev.sls
@@ -1,0 +1,2 @@
+liblzo2-dev:
+  pkg.installed

--- a/remnux/python3-packages/dissect.sls
+++ b/remnux/python3-packages/dissect.sls
@@ -18,10 +18,11 @@
 
 include:
   - remnux.python3-packages.pip
-#  - remnux.packages.python3-virtualenv
   - remnux.packages.virtualenv
   - remnux.packages.{{ py3_dependency }}
+  - remnux.packages.{{ py3_dependency }}-dev
   - remnux.packages.libfuse2
+  - remnux.packages.liblzo2-dev
 
 # Create a virtualenv for dissect
 remnux-python3-packages-dissect-virtualenv:
@@ -36,8 +37,10 @@ remnux-python3-packages-dissect-virtualenv:
       - tzdata
     - require:
       - sls: remnux.packages.{{ py3_dependency }}
+      - sls: remnux.packages.{{ py3_dependency }}-dev
       - sls: remnux.python3-packages.pip
-      - sls: remnux.packages.python3-virtualenv
+      - sls: remnux.packages.virtualenv
+      - sls: remnux.packages.liblzo2-dev
 
 # Install dissect inside the virtualenv
 remnux-python3-packages-dissect-install:


### PR DESCRIPTION
Recent changes to dissect's requirements are causing [Issue 189](https://github.com/REMnux/remnux-cli/issues/189). This PR will add the liblzo2-dev state and update the state to include this package and the necessary python3-dev package as well.