### PR TITLE
Change exiftool install method

### DIFF
--- a/remnux/perl-packages/exiftool.sls
+++ b/remnux/perl-packages/exiftool.sls
@@ -6,25 +6,51 @@
 # License: "This is free software; you can redistribute it and/or modify it under the same terms as Perl itself": https://exiftool.org/#license
 # Notes: exiftool
 
+{% set version = "12.98" %}
+ 
 include:
   - remnux.packages.perl
   - remnux.packages.build-essential
-  - remnux.packages.liblzma-dev
-  - remnux.packages.libssl-dev
-  - remnux.packages.zlib1g-dev
-  - remnux.packages.unzip
-  - remnux.perl-packages.net-ssleay
 
-remnux-perl-packages-exiftool:
+remnux-perl-packages-exiftool-download:
+  file.managed:
+    - name: /usr/local/src/remnux/files/Image-ExifTool-{{ version }}.tar.gz
+    - source: https://exiftool.org/Image-ExifTool-{{ version }}.tar.gz
+    - skip_verify: True
+    - makedirs: True
+
+remnux-perl-packages-exiftool-extract:
+  archive.extracted:
+    - name: /usr/local/src/remnux/exiftool
+    - source: /usr/local/src/remnux/files/Image-ExifTool-{{ version }}.tar.gz
+    - enforce_toplevel: False
+    - force: True
+    - require:
+      - file: remnux-perl-packages-exiftool-download
+
+remnux-perl-packages-exiftool-build:
   cmd.run:
-    - name: cpan install Image::ExifTool
-    - env:
-      - PERL_MM_USE_DEFAULT: 1
+    - name: perl Makefile.PL
+    - cwd: /usr/local/src/remnux/exiftool/Image-ExifTool-{{ version }}
     - require:
       - sls: remnux.packages.perl
       - sls: remnux.packages.build-essential
-      - sls: remnux.packages.liblzma-dev
-      - sls: remnux.packages.libssl-dev
-      - sls: remnux.packages.zlib1g-dev
-      - sls: remnux.packages.unzip
-      - sls: remnux.perl-packages.net-ssleay
+
+remnux-perl-packages-exiftool-install:
+  cmd.run:
+    - name: make install
+    - cwd: /usr/local/src/remnux/exiftool/Image-ExifTool-{{ version }}
+    - require:
+      - cmd: remnux-perl-packages-exiftool-build
+
+remnux-perl-packages-remove-exiftool-directory:
+  file.absent:
+    - name: /usr/local/src/remnux/exiftool
+    - require:
+      - cmd: remnux-perl-packages-exiftool-install
+
+remnux-perl-packages-remove-exiftool-archive:
+  file.absent:
+    - name: /usr/local/src/remnux/files/Image-ExifTool-{{ version }}.tar.gz
+    - require:
+      - cmd: remnux-perl-packages-exiftool-install

--- a/remnux/perl-packages/init.sls
+++ b/remnux/perl-packages/init.sls
@@ -5,7 +5,6 @@ include:
   - remnux.perl-packages.crypt-blowfish
   - remnux.perl-packages.digest-crc
   - remnux.perl-packages.ole-storagelite
-  - remnux.perl-packages.net-ssleay
 
 remnux-perl-packages:
   test.nop:
@@ -16,4 +15,3 @@ remnux-perl-packages:
       - sls: remnux.perl-packages.crypt-blowfish
       - sls: remnux.perl-packages.digest-crc
       - sls: remnux.perl-packages.ole-storagelite
-      - sls: remnux.perl-packages.net-ssleay


### PR DESCRIPTION
Exiftool installation has become longer to install using cpan and can occasionally stall or present errors in its tests which are inconsequential for the install. In order to avoid these issues, this PR will change the install method of exiftool, building using `perl` and `make` to complete the install from the archive sourced on the exiftool.org webpage.

This archive contains all necessary requirements to compile exiftool, and the compile process is only a few seconds, vice the amount of time it takes to install all dependencies manually and then install via cpan.