### PR TITLE
Fix saltstack infrastructure pointers

### DIFF
--- a/remnux/repos/saltstack.sls
+++ b/remnux/repos/saltstack.sls
@@ -1,7 +1,7 @@
 remnux-saltstack-key:
   file.managed:
-    - name: /usr/share/keyrings/salt-archive-keyring-2023.gpg
-    - source: https://repo.saltproject.io/salt/py3/ubuntu/{{ grains['lsb_distrib_release'] }}/{{ grains['osarch'] }}/SALT-PROJECT-GPG-PUBKEY-2023.gpg
+    - name: /usr/share/keyrings/salt-archive-keyring.pgp
+    - source: https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public
     - skip_verify: True
     - makedirs: True
 
@@ -17,18 +17,38 @@ saltstack-repo-cleanup2:
     - require:
       - pkgrepo: saltstack-repo-cleanup1
 
+saltstack-repo-cleanup3:
+  pkgrepo.absent:
+    - name: deb [arch={{ grains['osarch'] }}] https://repo.saltproject.io/py3/ubuntu/{{ grains['lsb_distrib_release'] }}/{{ grains['osarch'] }}/3006 focal main
+    - refresh: true
+    - require:
+      - pkgrepo: saltstack-repo-cleanup1
+
 saltstack-repo-file-absent:
   file.absent:
     - name: /etc/apt/sources.list.d/saltstack.list
 
+saltstack-repo-pin-version-3006:
+  file.managed:
+    - name: /etc/apt/preferences.d/salt-pin-1001
+    - mode: 755
+    - watch:
+      - file: saltstack-repo-file-absent
+    - contents:
+      - 'Package: salt-*'
+      - 'Pin: version 3006.*'
+      - 'Pin-Priority: 1001'
+
 saltstack-repo:
   pkgrepo.managed:
     - humanname: saltstack
-    - name: deb [signed-by=/usr/share/keyrings/salt-archive-keyring-2023.gpg arch={{ grains['osarch'] }}] https://repo.saltproject.io/salt/py3/ubuntu/{{ grains['lsb_distrib_release'] }}/{{ grains['osarch'] }}/3006 focal main
+    - name: deb [signed-by=/usr/share/keyrings/salt-archive-keyring.pgp arch={{ grains['osarch'] }}] https://packages.broadcom.com/artifactory/saltproject-deb/ stable main
     - file: /etc/apt/sources.list.d/saltstack.list
     - refresh: True
     - clean_file: True
     - require:
       - pkgrepo: saltstack-repo-cleanup2
+      - pkgrepo: saltstack-repo-cleanup3
       - file: saltstack-repo-file-absent
       - file: remnux-saltstack-key
+      - file: saltstack-repo-pin-version-3006


### PR DESCRIPTION
This will fix issue [194](https://github.com/REMnux/remnux-cli/issues/194) from the remnux-cli repo, whereby the recent changes to Saltstack infrastructure causes previous pointers to return 404 errors.