### PR TITLE
Add balbuzard back in

### DIFF
--- a/remnux/python3-packages/balbuzard.sls
+++ b/remnux/python3-packages/balbuzard.sls
@@ -1,0 +1,42 @@
+# Name: Balbuzard
+# Website: https://github.com/digitalsleuth/balbuzard
+# Description: Extract and deobfuscate patterns from suspicious files.
+# Category: Examine Static Properties: Deobfuscation
+# Author: Philippe Lagadec / Corey Forman (digitalsleuth)
+# License: Free, custom license: https://github.com/digitalsleuth/balbuzard
+# Notes: balbuzard, bbcrack, bbharvest, bbtrans
+
+{% set tools = ['balbuzard','bbcrack','bbharvest','bbtrans'] %}
+
+include:
+  - remnux.packages.virtualenv
+
+remnux-python3-packages-balbuzard-virtualenv:
+  virtualenv.managed:
+    - name: /opt/balbuzard
+    - python: /usr/bin/python3
+    - venv_bin: /usr/bin/virtualenv
+    - pip_pkgs:
+      - pip>=23.1.2
+      - setuptools>=70.0.0
+      - wheel>=0.38.4
+    - require:
+      - sls: remnux.packages.virtualenv
+
+remnux-python3-packages-balbuzard-install:
+  pip.installed:
+    - name: balbuzard-3
+    - bin_env: /opt/balbuzard/bin/python3
+    - upgrade: True
+    - require:
+      - virtualenv: remnux-python3-packages-balbuzard-virtualenv
+
+{% for tool in tools %}
+remnux-python3-packages-dissect-{{ tool }}-symlink:
+  file.symlink:
+    - name: /usr/local/bin/{{ tool }}
+    - target: /opt/balbuzard/bin/{{ tool }}
+    - makedirs: False
+    - require:
+      - pip: remnux-python3-packages-balbuzard-install
+{% endfor %}

--- a/remnux/python3-packages/init.sls
+++ b/remnux/python3-packages/init.sls
@@ -60,6 +60,7 @@ include:
 #  - remnux.python3-packages.fakenet-ng
   - remnux.python3-packages.pyenchant
   - remnux.python3-packages.vipermonkey
+  - remnux.python3-packages.balbuzard
 
 remnux-python3-packages:
   test.nop:
@@ -125,4 +126,4 @@ remnux-python3-packages:
 #      - sls: remnux.python3-packages.fakenet-ng
       - sls: remnux.python3-packages.pyenchant
       - sls: remnux.python3-packages.vipermonkey
-
+      - sls: remnux.python3-packages.balbuzard


### PR DESCRIPTION
This PR adds balbuzard back into REMnux after removing it due to it not being python 3 compatible. Now that it is python 3 compatible, the PR adds it back in using a virtualenv.