### PR TITLE
Add symlink creation to force overwrite previous

### DIFF
--- a/remnux/python3-packages/balbuzard.sls
+++ b/remnux/python3-packages/balbuzard.sls
@@ -36,6 +36,7 @@ remnux-python3-packages-dissect-{{ tool }}-symlink:
   file.symlink:
     - name: /usr/local/bin/{{ tool }}
     - target: /opt/balbuzard/bin/{{ tool }}
+    - force: True
     - makedirs: False
     - require:
       - pip: remnux-python3-packages-balbuzard-install


### PR DESCRIPTION
This fixes the issue with balbuzard failing to install when a previous install exists.