### PR TITLE
Updated cutter to the latest version.

### DIFF
--- a/remnux/tools/cutter.sls
+++ b/remnux/tools/cutter.sls
@@ -9,14 +9,14 @@
 remnux-tools-cutter-source:
   file.managed:
     - name: /usr/local/bin/cutter
-    - source: https://github.com/rizinorg/cutter/releases/download/v2.1.0/Cutter-v2.1.0-Linux-x86_64.AppImage
-    - source_hash: 9ca1e0dbd1e8e2a16167a1e261b9977ceb8cf127ab52d8e3de84a41dce099017
+    - source: https://github.com/rizinorg/cutter/releases/download/v2.4.1/Cutter-v2.4.1-Linux-x86_64.AppImage
+    - source_hash: 96a3af26feb29806d52e9b2639ce9d6917d6424ac2a5b991585a4e440e56eb40
     - mode: 755
 
 remnux-tools-cutter-icon:
   file.managed:
     - name: /usr/share/icons/cutter.svg
-    - source: https://raw.githubusercontent.com/rizinorg/cutter/v2.1.0/src/img/cutter.svg
+    - source: https://raw.githubusercontent.com/rizinorg/cutter/v2.4.1/src/img/cutter.svg
     - source_hash: 4ad117f6d8fc9fffc1359d1eef7f3f1c68db0f74eebebc998fa47b89bab81832
     - mode: 644
     - makedirs: True


### PR DESCRIPTION
Updated Cutter to the latest version 2.4.1.

Tested via [salt-call](https://docs.remnux.org/get-involved/add-or-update-tools#id-4.-test-the-salt-state-file) and manually downloading and testing the new release.