### PR TITLE
Update exiftool version to 13.32 in Salt state file

### DIFF
--- a/remnux/perl-packages/exiftool.sls
+++ b/remnux/perl-packages/exiftool.sls
@@ -6,7 +6,7 @@
 # License: "This is free software; you can redistribute it and/or modify it under the same terms as Perl itself": https://exiftool.org/#license
 # Notes: exiftool
 
-{% set version = "12.98" %}
+{% set version = "13.32" %}
  
 include:
   - remnux.packages.perl


### PR DESCRIPTION
The previous version (12.98) is no longer available on https://exiftool.org/, resulting in a 404 error during the file download step. This update sets the version to 13.32, the latest available release.

fixes #315 