### PR TITLE
Update exiftool to 13.33 in Salt state file

### DIFF
--- a/remnux/perl-packages/exiftool.sls
+++ b/remnux/perl-packages/exiftool.sls
@@ -6,8 +6,8 @@
 # License: "This is free software; you can redistribute it and/or modify it under the same terms as Perl itself": https://exiftool.org/#license
 # Notes: exiftool
 
-{% set version = "13.32" %}
- 
+{% set version = "13.33" %}
+
 include:
   - remnux.packages.perl
   - remnux.packages.build-essential


### PR DESCRIPTION
The previous version (13.32) is no longer available on https://exiftool.org/, resulting in a 404 error during the file download step. This update sets the version to 13.33, the latest available release.