### PR TITLE
Prevent versioning issues

### DIFF
--- a/remnux/python3-packages/distro-info.sls
+++ b/remnux/python3-packages/distro-info.sls
@@ -1,0 +1,6 @@
+distro-info:
+  pkg.removed
+
+python3-distro-info:
+  pkg.removed
+

--- a/remnux/python3-packages/init.sls
+++ b/remnux/python3-packages/init.sls
@@ -1,4 +1,6 @@
 include:
+  - remnux.python3-packages.distro-info
+  - remnux.python3-packages.python-debian
   - remnux.python3-packages.androguard
   - remnux.python3-packages.ioc-parser
   - remnux.python3-packages.ipwhois
@@ -24,7 +26,7 @@ include:
   - remnux.python3-packages.malwoverview
   - remnux.python3-packages.chepy
   - remnux.python3-packages.frida
-  - remnux.python3-packages.stringsifter
+##  - remnux.python3-packages.stringsifter
   - remnux.python3-packages.oletools
   - remnux.python3-packages.unfurl
   - remnux.python3-packages.speakeasy
@@ -56,6 +58,8 @@ include:
 remnux-python3-packages:
   test.nop:
     - require:
+      - sls: remnux.python3-packages.distro-info
+      - sls: remnux.python3-packages.python-debian
       - sls: remnux.python3-packages.androguard
       - sls: remnux.python3-packages.ioc-parser
       - sls: remnux.python3-packages.ipwhois
@@ -83,7 +87,7 @@ remnux-python3-packages:
       - sls: remnux.python3-packages.malwoverview
       - sls: remnux.python3-packages.chepy
       - sls: remnux.python3-packages.frida
-      - sls: remnux.python3-packages.stringsifter
+##      - sls: remnux.python3-packages.stringsifter
       ## stringsifter - pyproject.toml pins numpy at 1.24.4 but is not compatible with noble
       - sls: remnux.python3-packages.oletools
       - sls: remnux.python3-packages.unfurl

--- a/remnux/python3-packages/python-debian.sls
+++ b/remnux/python3-packages/python-debian.sls
@@ -1,0 +1,2 @@
+python-debian:
+  pkg.removed

--- a/remnux/python3-packages/speakeasy.sls
+++ b/remnux/python3-packages/speakeasy.sls
@@ -10,6 +10,7 @@
 
 include:
   - remnux.packages.python3-virtualenv
+  - remnux.packages.python3-pip
 
 remnux-python3-packages-remove-speakeasy:
   pip.removed:


### PR DESCRIPTION
There are two packages, `distro-info` (and it's python3 package equivalent), and `python-debian` which do not fit the proper versioning structure now enforced by setuptools, pip, etc. Since these packages are not necessary for the installation of python packages, this PR adds two states into `python3-packages` which will remove the apt / python version of these to ensure there is no collision with an unsupported version.

These states are added into `python3-packages` specifically to ensure they run in accordance with the appropriate order of operations.

The PR also fixes two other issues which were encountered during this troubleshooting process.