### PR TITLE
Update exiftool.sls

### DIFF
--- a/remnux/perl-packages/exiftool.sls
+++ b/remnux/perl-packages/exiftool.sls
@@ -6,7 +6,7 @@
 # License: "This is free software; you can redistribute it and/or modify it under the same terms as Perl itself": https://exiftool.org/#license
 # Notes: exiftool
 
-{% set version = "13.33" %}
+{% set version = "13.34" %}
 
 include:
   - remnux.packages.perl


### PR DESCRIPTION
It was released version Exif Tool 13.34 and version 13.33 is not available anymore, causing Error 404. Just a workarround until a more robust solution with version auto detection be implemented on master branch.