### PR TITLE
Final updates to support 24

### DIFF
--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -83,7 +83,7 @@ include:
   - remnux.packages.strace
   - remnux.packages.subversion
   - remnux.packages.swftools
-  - remnux.packages.sysdig
+#  - remnux.packages.sysdig
   - remnux.packages.tcpdump
   - remnux.packages.tcpflow
   - remnux.packages.tcpick
@@ -246,7 +246,7 @@ remnux-packages:
       - sls: remnux.packages.strace
       - sls: remnux.packages.subversion
       - sls: remnux.packages.swftools
-      - sls: remnux.packages.sysdig
+#      - sls: remnux.packages.sysdig
       - sls: remnux.packages.tcpdump
       - sls: remnux.packages.tcpflow
       - sls: remnux.packages.tcpick

--- a/remnux/packages/wine.sls
+++ b/remnux/packages/wine.sls
@@ -6,6 +6,12 @@
 # License: GNU Lesser General Public License (LGPL) v2.1 or later: https://wiki.winehq.org/Licensing
 # Notes: wine
 
+{% if grains['oscodename'] == 'noble' %}
+  {% set libncurses = 'libncurses6' %}
+{% else %}
+  {% set libncurses = 'libncurses5' %}
+{% endif %} 
+
 include:
   - remnux.repos.winehq
 
@@ -16,8 +22,8 @@ remnux-packages-wine-i386-architecture:
 
 remnux-packages-wine-i386-deps:
   cmd.run:
-    - name: apt-get install -y libc6:i386 libstdc++6:i386 libncurses5:i386 zlib1g:i386
-    - unless: dpkg -l | grep -q "ii  libncurses5:i386" && dpkg -l | grep -q "ii  zlib1g:i386"
+    - name: apt-get install -y libc6:i386 libstdc++6:i386 {{ libncurses }}:i386 zlib1g:i386 --install-recommends
+    - unless: dpkg -l | grep -q "ii  {{ libncurses }}:i386" && dpkg -l | grep -q "ii  zlib1g:i386"
     - require:
       - cmd: remnux-packages-wine-i386-architecture
 


### PR DESCRIPTION
This PR includes the final modifications to make REMnux compatible with Ubuntu 24.04. Sysdig is temporarily disabled as the software does not properly install with modern Noble kernels. This is noted in [this issue](https://github.com/draios/sysdig/issues/2151) from the sysdig repo.

This also fixes the wine requirements, by modifying the logic for libncurses depending on the version of Ubuntu.