### PR TITLE
PolarProxy 2.0.1

### DIFF
--- a/remnux/tools/polarproxy.sls
+++ b/remnux/tools/polarproxy.sls
@@ -8,16 +8,16 @@
 
 remnux-polarproxy-source:
   file.managed:
-    - name: /usr/local/src/remnux/files/PolarProxy_2.0.0_linux-x64.tar.gz
-    - source: https://download.netresec.com/polarproxy/PolarProxy_2.0.0_linux-x64.tar.gz
-    - source_hash: sha256=d0e6d2058efd7e84289c05814117b5e23f090abed4d496750b89c99ac004925e
+    - name: /usr/local/src/remnux/files/PolarProxy_2.0.1_linux-x64.tar.gz
+    - source: https://download.netresec.com/polarproxy/PolarProxy_2.0.1_linux-x64.tar.gz
+    - source_hash: sha256=42b4b74999d80269adf3e73e8e24edb0427b8b2eb29d216df7215a7eebacaf73
     - makedirs: True
     - replace: False
 
 remnux-polarproxy-archive:
   archive.extracted:
     - name: /usr/local/polarproxy/
-    - source: /usr/local/src/remnux/files/PolarProxy_2.0.0_linux-x64.tar.gz
+    - source: /usr/local/src/remnux/files/PolarProxy_2.0.1_linux-x64.tar.gz
     - enforce_toplevel: False
     - force: true
     - watch:


### PR DESCRIPTION
PolarProxy 2.0.1 released
https://netresec.com/?b=266dc11

There is also a musl Linux (for Alpine) download available here, if that's preferred:
https://download.netresec.com/polarproxy/PolarProxy_2.0.1_linux-musl-x64.tar.gz