### PR TITLE
Add Lyrebird internet-services emulator (python3-packages)

### DIFF
--- a/remnux/python3-packages/init.sls
+++ b/remnux/python3-packages/init.sls
@@ -53,6 +53,7 @@ include:
   - remnux.python3-packages.apkid
   - remnux.python3-packages.pyinstxtractor-ng
   - remnux.python3-packages.uncompyle6
+  - remnux.python3-packages.lyrebird
 
 remnux-python3-packages:
   test.nop:
@@ -111,3 +112,4 @@ remnux-python3-packages:
       - sls: remnux.python3-packages.apkid
       - sls: remnux.python3-packages.pyinstxtractor-ng
       - sls: remnux.python3-packages.uncompyle6
+      - sls: remnux.python3-packages.lyrebird

--- a/remnux/python3-packages/lyrebird.sls
+++ b/remnux/python3-packages/lyrebird.sls
@@ -1,0 +1,39 @@
+# Name: Lyrebird
+# Website: https://github.com/cac0ns3c/Lyrebird
+# Description: Emulate internet services (HTTP, DNS, SMTP, IRC, and more) to keep detonating malware talking while capturing every interaction as structured JSONL; a modern successor to INetSim with first-class detection telemetry.
+# Category: Explore Network Interactions: Services
+# Author: Lyrebird contributors: https://github.com/cac0ns3c/Lyrebird/graphs/contributors
+# License: GPL-3.0-or-later: https://github.com/cac0ns3c/Lyrebird/blob/main/LICENSE
+# Notes: Run the tool using `lyrebird` (built-in defaults apply) or point it at a config with `lyrebird --config /path/to/lyrebird.yaml`. A sample config lives at config/lyrebird.yaml in the project repository.
+
+include:
+  - remnux.packages.python3-virtualenv
+
+remnux-python3-packages-lyrebird-venv:
+  virtualenv.managed:
+    - name: /opt/lyrebird
+    - venv_bin: /usr/bin/virtualenv
+    - pip_pkgs:
+      - pip>=24.1.3
+      - setuptools>=77.0.0
+      - wheel>=0.38.4
+      - importlib-metadata>=8.0.0
+    - require:
+      - sls: remnux.packages.python3-virtualenv
+
+remnux-python3-packages-lyrebird:
+  pip.installed:
+    - name: lyrebird-emulator
+    - bin_env: /opt/lyrebird/bin/python3
+    - upgrade: True
+    - require:
+      - virtualenv: remnux-python3-packages-lyrebird-venv
+
+remnux-python3-packages-lyrebird-symlink:
+  file.symlink:
+    - name: /usr/local/bin/lyrebird
+    - target: /opt/lyrebird/bin/lyrebird
+    - force: True
+    - makedirs: False
+    - require:
+      - pip: remnux-python3-packages-lyrebird


### PR DESCRIPTION
## Add Lyrebird — internet-services emulator (python3-packages)

This adds a Salt state to install **Lyrebird**, a modern successor to INetSim for malware-analysis labs. It stands up fake-but-believable network services (HTTP, DNS, SMTP, POP3, IMAP, FTP, TFTP, IRC, NTP, TLS, and more — 16 services) so a sample detonating in an isolated sandbox keeps talking, while every interaction is captured as structured JSONL. Detection telemetry (paired Sigma rules and session analytics) is a first-class output.

- **Website:** https://github.com/cac0ns3c/Lyrebird
- **PyPI:** https://pypi.org/project/lyrebird-emulator/ (v0.2.0)
- **License:** GPL-3.0-or-later
- **Category:** Explore Network Interactions: Services (alongside FakeNet-NG and fakemail)

### What this PR does
- Adds `remnux/python3-packages/lyrebird.sls`, following the `fakemail.sls` / `fakenet-ng.sls` pattern: creates a dedicated virtualenv at `/opt/lyrebird`, pip-installs `lyrebird-emulator` from PyPI, and symlinks the `lyrebird` CLI into `/usr/local/bin`.
- Registers the state in `remnux/python3-packages/init.sls` (both the `include` list and the `test.nop` require block).

### Testing
- `lyrebird-emulator` installs cleanly from PyPI into a fresh virtualenv; the `lyrebird` console entry point runs (`lyrebird --help`).
- Both `.sls` files parse as valid YAML.

### Notes
Run with `lyrebird` (built-in defaults apply) or `lyrebird --config /path/to/lyrebird.yaml`. A sample config lives at `config/lyrebird.yaml` in the project repo.
